### PR TITLE
fix: language is type string now

### DIFF
--- a/src/telegram_bot/types/message_entity.cr
+++ b/src/telegram_bot/types/message_entity.cr
@@ -7,7 +7,7 @@ module TelegramBot
     property length : Int32
     property url : String?
     property user : User?
-    property language : User?
+    property language : String?
 
     def initialize(
       @type : String,
@@ -16,7 +16,7 @@ module TelegramBot
       *,
       @url = nil,
       @user = nil,
-      @language = nil,
+      @language : String? = nil,
     )
     end
   end


### PR DESCRIPTION
The original code expected language to be a User object, but Telegram API sends it as a string representing the programming language of code blocks (e.g., "```python" becomes language: "python").

This fix resolves the JSON::ParseException that occurred when processing modern Telegram messages containing formatted code.

This patch fixes #7.