### PR TITLE
Fix broken Telegram API wrapper mappings

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -19,14 +19,11 @@ jobs:
         run: crystal tool format --check
   check_ameba:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: shards install --ignore-crystal-version
-      - name: Check ameba
-        run: ./bin/ameba
+      - name: Check out repository code
+        uses: actions/checkout@v6
+      - name: Run Ameba linter
+        uses: crystal-ameba/github-action@master
   test_latest:
     runs-on: ubuntu-latest
     container:

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
 Copyright (c) 2015-2020 Krisztián Ádám
-Copyright (c) 2020-2025 Anton Maminov
+Copyright (c) 2020-2026 Anton Maminov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,340 @@
+# Telegram Bot API Upgrade TODO
+
+This shard currently targets an old Telegram Bot API surface. Use this plan to
+upgrade it in small, reviewable steps. Prefer adding focused specs per step and
+keeping backward-compatible method signatures where practical.
+
+## Phase 0: Existing Wrapper Fixes
+
+- [x] Fix `send_photo` so it sends `caption`.
+- [x] Fix `send_audio` to call `sendAudio`, not `sendPhoto`.
+- [x] Fix `send_video_note` to send the `video_note` parameter and remove
+      references to unrelated variables.
+- [x] Fix `send_invoice` typo so the public argument and submitted parameter are
+      `title`, not `tilte`.
+- [x] Fix `send_contact` to expose and send `disable_notification` if supported
+      by the local wrapper.
+- [x] Review duplicate/obsolete wrappers in `bot.cr` such as duplicate
+      `pin_chat_message` and `unpin_chat_message`.
+- [x] Dispatch payment query updates already present in `Update`:
+  - [x] `shipping_query`
+  - [x] `pre_checkout_query`
+- [x] Fix `answer_shipping_query` to send `shipping_options`.
+- [x] Add focused request-building specs for the fixed methods.
+
+## Phase 1: Request Serialization Foundation
+
+- [ ] Add a shared helper for JSON-serializing API parameters that are arrays or
+      `JSON::Serializable` objects.
+- [ ] Ensure `allowed_updates`, media arrays, command arrays, inline results,
+      reply markup, and future object parameters are serialized consistently.
+- [ ] Decide whether to keep form-encoded requests as the default or introduce
+      JSON request bodies for non-file requests.
+- [ ] Improve multipart handling enough for binary-safe file uploads.
+
+## Phase 2: Core Update Dispatch
+
+- [ ] Add missing `Update` fields:
+  - [ ] `shipping_query`
+  - [ ] `pre_checkout_query`
+  - [ ] `poll`
+  - [ ] `poll_answer`
+  - [ ] `my_chat_member`
+  - [ ] `chat_member`
+  - [ ] `chat_join_request`
+  - [ ] `message_reaction`
+  - [ ] `message_reaction_count`
+  - [ ] `business_connection`
+  - [ ] `business_message`
+  - [ ] `edited_business_message`
+  - [ ] `deleted_business_messages`
+  - [ ] `purchased_paid_media`
+  - [ ] `chat_boost`
+  - [ ] `removed_chat_boost`
+  - [ ] `guest_message`
+  - [ ] `managed_bot`
+- [ ] Add overridable handler methods for the update types above.
+- [ ] Update `handle_update` to dispatch all supported update fields.
+- [ ] Keep existing handler behavior backward-compatible.
+
+## Phase 3: Modern Core Message Types
+
+- [ ] Add or update shared message-related types:
+  - [ ] `MessageId`
+  - [ ] `InaccessibleMessage`
+  - [ ] `MaybeInaccessibleMessage`
+  - [ ] `ReplyParameters`
+  - [ ] `TextQuote`
+  - [ ] `ExternalReplyInfo`
+  - [ ] `LinkPreviewOptions`
+  - [ ] `MessageOriginUser`
+  - [ ] `MessageOriginHiddenUser`
+  - [ ] `MessageOriginChat`
+  - [ ] `MessageOriginChannel`
+- [ ] Expand `Message` with common modern fields:
+  - [ ] `message_thread_id`
+  - [ ] `direct_messages_topic`
+  - [ ] `sender_chat`
+  - [ ] `sender_boost_count`
+  - [ ] `sender_business_bot`
+  - [ ] `business_connection_id`
+  - [ ] `forward_origin`
+  - [ ] `is_topic_message`
+  - [ ] `is_automatic_forward`
+  - [ ] `reply_to_message`
+  - [ ] `external_reply`
+  - [ ] `quote`
+  - [ ] `reply_to_story`
+  - [ ] `reply_to_checklist_task_id`
+  - [ ] `reply_to_poll_option_id`
+  - [ ] `has_protected_content`
+  - [ ] `is_from_offline`
+  - [ ] `is_paid_post`
+  - [ ] `paid_star_count`
+  - [ ] `effect_id`
+  - [ ] `show_caption_above_media`
+  - [ ] `has_media_spoiler`
+  - [ ] `reply_markup`
+- [ ] Expand `MessageEntity` with modern fields:
+  - [ ] `custom_emoji_id`
+  - [ ] support documented modern entity types such as `custom_emoji`,
+        `blockquote`, `expandable_blockquote`, and `date_time`.
+
+## Phase 4: Common Media And Interaction Types
+
+- [ ] Add `Animation` sending support where missing from methods.
+- [ ] Add `Dice`.
+- [ ] Add poll types:
+  - [ ] `Poll`
+  - [ ] `PollOption`
+  - [ ] `InputPollOption`
+  - [ ] `InputPollMedia`
+  - [ ] `InputPollOptionMedia`
+  - [ ] `PollAnswer`
+  - [ ] `PollOptionAdded`
+  - [ ] `PollOptionDeleted`
+- [ ] Add reaction types:
+  - [ ] `ReactionTypeEmoji`
+  - [ ] `ReactionTypeCustomEmoji`
+  - [ ] `ReactionTypePaid`
+  - [ ] `MessageReactionUpdated`
+  - [ ] `MessageReactionCountUpdated`
+  - [ ] `ReactionCount`
+- [ ] Add forum topic service types:
+  - [ ] `ForumTopic`
+  - [ ] `ForumTopicCreated`
+  - [ ] `ForumTopicEdited`
+  - [ ] `ForumTopicClosed`
+  - [ ] `ForumTopicReopened`
+  - [ ] `GeneralForumTopicHidden`
+  - [ ] `GeneralForumTopicUnhidden`
+
+## Phase 5: Common Sending Methods
+
+- [ ] Add `send_animation`.
+- [ ] Add `send_poll`.
+- [ ] Add `send_dice`.
+- [ ] Add `copy_message`.
+- [ ] Add `copy_messages`.
+- [ ] Add `forward_messages`.
+- [ ] Add `send_message_draft`.
+- [ ] Add shared modern optional params to sending methods:
+  - [ ] `business_connection_id`
+  - [ ] `message_thread_id`
+  - [ ] `direct_messages_topic_id`
+  - [ ] `parse_mode`
+  - [ ] `entities`
+  - [ ] `caption_entities`
+  - [ ] `link_preview_options`
+  - [ ] `protect_content`
+  - [ ] `disable_notification`
+  - [ ] `reply_parameters`
+  - [ ] `reply_markup`
+  - [ ] `message_effect_id`
+  - [ ] `allow_paid_broadcast`
+  - [ ] `suggested_post_parameters`
+- [ ] Add media-specific modern params where applicable:
+  - [ ] `thumbnail`
+  - [ ] `cover`
+  - [ ] `start_timestamp`
+  - [ ] `has_spoiler`
+  - [ ] `show_caption_above_media`
+  - [ ] `supports_streaming`
+
+## Phase 6: Webhook And Bot Metadata Methods
+
+- [ ] Add `get_webhook_info` and `WebhookInfo`.
+- [ ] Extend `set_webhook` with:
+  - [ ] `ip_address`
+  - [ ] `drop_pending_updates`
+  - [ ] `secret_token`
+- [ ] Extend `delete_webhook` with `drop_pending_updates`.
+- [ ] Add command scopes:
+  - [ ] `BotCommandScopeDefault`
+  - [ ] `BotCommandScopeAllPrivateChats`
+  - [ ] `BotCommandScopeAllGroupChats`
+  - [ ] `BotCommandScopeAllChatAdministrators`
+  - [ ] `BotCommandScopeChat`
+  - [ ] `BotCommandScopeChatAdministrators`
+  - [ ] `BotCommandScopeChatMember`
+- [ ] Extend `set_my_commands` and `get_my_commands` with `scope` and
+      `language_code`.
+- [ ] Add `delete_my_commands`.
+- [ ] Add bot profile methods and types:
+  - [ ] `set_my_name`, `get_my_name`, `BotName`
+  - [ ] `set_my_description`, `get_my_description`, `BotDescription`
+  - [ ] `set_my_short_description`, `get_my_short_description`,
+        `BotShortDescription`
+  - [ ] `set_my_default_administrator_rights`
+  - [ ] `get_my_default_administrator_rights`
+
+## Phase 7: Chat Administration
+
+- [ ] Add `ChatPermissions`.
+- [ ] Add modern `ChatMember` variants or expand current `ChatMember`:
+  - [ ] owner
+  - [ ] administrator
+  - [ ] member
+  - [ ] restricted
+  - [ ] left
+  - [ ] banned
+- [ ] Add `ChatMemberUpdated`.
+- [ ] Add `ChatInviteLink`.
+- [ ] Add `ChatJoinRequest`.
+- [ ] Add invite link methods:
+  - [ ] `create_chat_invite_link`
+  - [ ] `edit_chat_invite_link`
+  - [ ] `create_chat_subscription_invite_link`
+  - [ ] `edit_chat_subscription_invite_link`
+  - [ ] `revoke_chat_invite_link`
+- [ ] Add join request methods:
+  - [ ] `approve_chat_join_request`
+  - [ ] `decline_chat_join_request`
+- [ ] Add forum methods:
+  - [ ] `get_forum_topic_icon_stickers`
+  - [ ] `create_forum_topic`
+  - [ ] `edit_forum_topic`
+  - [ ] `close_forum_topic`
+  - [ ] `reopen_forum_topic`
+  - [ ] `delete_forum_topic`
+  - [ ] `unpin_all_forum_topic_messages`
+  - [ ] `edit_general_forum_topic`
+  - [ ] `close_general_forum_topic`
+  - [ ] `reopen_general_forum_topic`
+  - [ ] `hide_general_forum_topic`
+  - [ ] `unhide_general_forum_topic`
+  - [ ] `unpin_all_general_forum_topic_messages`
+- [ ] Add reaction methods:
+  - [ ] `set_message_reaction`
+  - [ ] `delete_message_reaction`
+  - [ ] `delete_all_message_reactions`
+
+## Phase 8: Keyboard, Inline, And Web App Support
+
+- [ ] Expand `InlineKeyboardButton` with:
+  - [ ] `login_url`
+  - [ ] `web_app`
+  - [ ] `switch_inline_query_current_chat`
+  - [ ] `switch_inline_query_chosen_chat`
+  - [ ] `copy_text`
+  - [ ] `callback_game`
+  - [ ] `pay`
+  - [ ] `icon_custom_emoji_id`
+  - [ ] `style`
+- [ ] Add keyboard/web app types:
+  - [ ] `LoginUrl`
+  - [ ] `WebAppInfo`
+  - [ ] `WebAppData`
+  - [ ] `SwitchInlineQueryChosenChat`
+  - [ ] `CopyTextButton`
+- [ ] Expand `KeyboardButton` with:
+  - [ ] `request_users`
+  - [ ] `request_chat`
+  - [ ] `request_contact`
+  - [ ] `request_location`
+  - [ ] `request_poll`
+  - [ ] `web_app`
+  - [ ] `request_managed_bot`
+  - [ ] `icon_custom_emoji_id`
+  - [ ] `style`
+- [ ] Add `KeyboardButtonRequestUsers`.
+- [ ] Add `KeyboardButtonRequestChat`.
+- [ ] Add `KeyboardButtonPollType`.
+- [ ] Add `KeyboardButtonRequestManagedBot`.
+- [ ] Add `answer_web_app_query`.
+- [ ] Add `SentWebAppMessage`.
+- [ ] Add `save_prepared_inline_message`.
+- [ ] Add `PreparedInlineMessage`.
+- [ ] Add `save_prepared_keyboard_button`.
+- [ ] Add `PreparedKeyboardButton`.
+
+## Phase 9: Payments, Stars, Gifts, Paid Media
+
+- [ ] Add modern payment fields:
+  - [ ] `RefundedPayment`
+  - [ ] `RevenueWithdrawalState`
+  - [ ] `TransactionPartner`
+  - [ ] `StarTransaction`
+  - [ ] `StarTransactions`
+  - [ ] `StarAmount`
+- [ ] Add paid media types:
+  - [ ] `PaidMediaInfo`
+  - [ ] `PaidMediaPreview`
+  - [ ] `PaidMediaPhoto`
+  - [ ] `PaidMediaVideo`
+  - [ ] `PaidMediaLivePhoto`
+  - [ ] `InputPaidMediaPhoto`
+  - [ ] `InputPaidMediaVideo`
+  - [ ] `InputPaidMediaLivePhoto`
+- [ ] Add paid media methods:
+  - [ ] `send_paid_media`
+  - [ ] `get_star_transactions`
+  - [ ] `refund_star_payment`
+  - [ ] `edit_user_star_subscription`
+- [ ] Add gift types and methods if needed by downstream users.
+
+## Phase 10: Business, Guest, And Managed Bot Support
+
+- [ ] Add business connection types:
+  - [ ] `BusinessConnection`
+  - [ ] `BusinessMessagesDeleted`
+  - [ ] `BusinessBotRights`
+  - [ ] `BusinessIntro`
+  - [ ] `BusinessLocation`
+  - [ ] `BusinessOpeningHours`
+- [ ] Add business methods:
+  - [ ] `get_business_connection`
+  - [ ] `read_business_message`
+  - [ ] `delete_business_messages`
+  - [ ] `set_business_account_name`
+  - [ ] `set_business_account_username`
+  - [ ] `set_business_account_bio`
+  - [ ] `set_business_account_profile_photo`
+  - [ ] `remove_business_account_profile_photo`
+  - [ ] `set_business_account_gift_settings`
+- [ ] Add guest mode support:
+  - [ ] `SentGuestMessage`
+  - [ ] `answer_guest_query`
+- [ ] Add managed bot support:
+  - [ ] `ManagedBotUpdated`
+  - [ ] `ManagedBotCreated`
+  - [ ] `BotAccessSettings`
+  - [ ] `get_managed_bot_token`
+  - [ ] `replace_managed_bot_token`
+  - [ ] `get_managed_bot_access_settings`
+  - [ ] `set_managed_bot_access_settings`
+
+## Phase 11: Documentation And Compatibility
+
+- [ ] Update README with the supported Bot API version.
+- [ ] Document known compatibility behavior for old method arguments like
+      `reply_to_message_id` versus `reply_parameters`.
+- [ ] Add examples for:
+  - [ ] command bot
+  - [ ] inline keyboard callback bot
+  - [ ] poll bot
+  - [ ] forum topic bot
+  - [ ] webhook with `secret_token`
+- [ ] Add a support matrix listing implemented methods and types.
+- [ ] Decide whether to keep deprecated Telegram API aliases or mark them with
+      comments before removal in a future major release.

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -106,22 +106,24 @@ describe TelegramBot::Bot do
 
   it "dispatches shipping queries" do
     bot = RequestBuildingBot.new
-    update = TelegramBot::Update.from_json(%({
-      "update_id": 1,
-      "shipping_query": {
-        "id": "shipping-id",
-        "from": {"id": 1, "is_bot": false, "first_name": "User"},
-        "invoice_payload": "payload",
-        "shipping_address": {
-          "country_code": "US",
-          "state": "CA",
-          "city": "San Francisco",
-          "street_line1": "Market",
-          "street_line2": "",
-          "post_code": "94103"
+    update = TelegramBot::Update.from_json(<<-JSON)
+      {
+        "update_id": 1,
+        "shipping_query": {
+          "id": "shipping-id",
+          "from": {"id": 1, "is_bot": false, "first_name": "User"},
+          "invoice_payload": "payload",
+          "shipping_address": {
+            "country_code": "US",
+            "state": "CA",
+            "city": "San Francisco",
+            "street_line1": "Market",
+            "street_line2": "",
+            "post_code": "94103"
+          }
         }
       }
-    }))
+      JSON
 
     bot.handle_update(update)
 
@@ -130,16 +132,18 @@ describe TelegramBot::Bot do
 
   it "dispatches pre-checkout queries" do
     bot = RequestBuildingBot.new
-    update = TelegramBot::Update.from_json(%({
-      "update_id": 1,
-      "pre_checkout_query": {
-        "id": "pre-checkout-id",
-        "from": {"id": 1, "is_bot": false, "first_name": "User"},
-        "currency": "USD",
-        "total_amount": 1000,
-        "invoice_payload": "payload"
+    update = TelegramBot::Update.from_json(<<-JSON)
+      {
+        "update_id": 1,
+        "pre_checkout_query": {
+          "id": "pre-checkout-id",
+          "from": {"id": 1, "is_bot": false, "first_name": "User"},
+          "currency": "USD",
+          "total_amount": 1000,
+          "invoice_payload": "payload"
+        }
       }
-    }))
+      JSON
 
     bot.handle_update(update)
 

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -1,0 +1,148 @@
+require "./spec_helper"
+
+class RequestBuildingBot < TelegramBot::Bot
+  getter last_method, last_force_http, last_params, handled_update
+
+  def initialize
+    super "testbot", "token"
+    @last_method = nil.as(String?)
+    @last_force_http = nil.as(Bool?)
+    @last_params = {} of String => String?
+    @handled_update = nil.as(String?)
+  end
+
+  protected def request(method : String, force_http : Bool = false, params = nil)
+    @last_method = method
+    @last_force_http = force_http
+    @last_params = {} of String => String?
+
+    params.try &.each do |key, value|
+      @last_params[key] = value.nil? ? nil : value.to_s
+    end
+
+    case method
+    when "answerShippingQuery", "answerPreCheckoutQuery", "pinChatMessage", "unpinChatMessage"
+      JSON.parse("true")
+    else
+      JSON.parse(%({"message_id":1,"date":0,"chat":{"id":1,"type":"private"}}))
+    end
+  end
+
+  def handle(shipping_query : TelegramBot::ShippingQuery)
+    @handled_update = shipping_query.id
+  end
+
+  def handle(pre_checkout_query : TelegramBot::PreCheckoutQuery)
+    @handled_update = pre_checkout_query.id
+  end
+end
+
+describe TelegramBot::Bot do
+  it "builds sendPhoto with caption" do
+    bot = RequestBuildingBot.new
+    bot.send_photo(123, "photo-id", caption: "caption")
+
+    bot.last_method.should eq("sendPhoto")
+    bot.last_params["photo"].should eq("photo-id")
+    bot.last_params["caption"].should eq("caption")
+  end
+
+  it "builds sendAudio with the correct method" do
+    bot = RequestBuildingBot.new
+    bot.send_audio(123, "audio-id", duration: 10, performer: "performer", title: "title")
+
+    bot.last_method.should eq("sendAudio")
+    bot.last_params["audio"].should eq("audio-id")
+    bot.last_params["duration"].should eq("10")
+    bot.last_params["performer"].should eq("performer")
+    bot.last_params["title"].should eq("title")
+  end
+
+  it "builds sendVideoNote with video_note" do
+    bot = RequestBuildingBot.new
+    bot.send_video_note(123, "video-note-id", duration: 10, length: 240)
+
+    bot.last_method.should eq("sendVideoNote")
+    bot.last_params["video_note"].should eq("video-note-id")
+    bot.last_params["duration"].should eq("10")
+    bot.last_params["length"].should eq("240")
+  end
+
+  it "builds sendInvoice with title" do
+    bot = RequestBuildingBot.new
+    bot.send_invoice(
+      chat_id: 123,
+      title: "invoice title",
+      description: "description",
+      payload: "payload",
+      provider_token: "provider-token",
+      start_parameter: "start",
+      currency: "USD",
+      prices: [] of TelegramBot::LabeledPrice
+    )
+
+    bot.last_method.should eq("sendInvoice")
+    bot.last_params["title"].should eq("invoice title")
+    bot.last_params.has_key?("tilte").should be_false
+  end
+
+  it "builds sendContact with disable_notification" do
+    bot = RequestBuildingBot.new
+    bot.send_contact(123, "+15550100", "First", disable_notification: true)
+
+    bot.last_method.should eq("sendContact")
+    bot.last_params["disable_notification"].should eq("true")
+  end
+
+  it "builds answerShippingQuery with shipping_options" do
+    bot = RequestBuildingBot.new
+    bot.answer_shipping_query("query-id", true, [] of TelegramBot::ShippingOption)
+
+    bot.last_method.should eq("answerShippingQuery")
+    bot.last_params["shipping_query_id"].should eq("query-id")
+    bot.last_params["shipping_options"].should eq("[]")
+    bot.last_params.has_key?("shipping_option").should be_false
+  end
+
+  it "dispatches shipping queries" do
+    bot = RequestBuildingBot.new
+    update = TelegramBot::Update.from_json(%({
+      "update_id": 1,
+      "shipping_query": {
+        "id": "shipping-id",
+        "from": {"id": 1, "is_bot": false, "first_name": "User"},
+        "invoice_payload": "payload",
+        "shipping_address": {
+          "country_code": "US",
+          "state": "CA",
+          "city": "San Francisco",
+          "street_line1": "Market",
+          "street_line2": "",
+          "post_code": "94103"
+        }
+      }
+    }))
+
+    bot.handle_update(update)
+
+    bot.handled_update.should eq("shipping-id")
+  end
+
+  it "dispatches pre-checkout queries" do
+    bot = RequestBuildingBot.new
+    update = TelegramBot::Update.from_json(%({
+      "update_id": 1,
+      "pre_checkout_query": {
+        "id": "pre-checkout-id",
+        "from": {"id": 1, "is_bot": false, "first_name": "User"},
+        "currency": "USD",
+        "total_amount": 1000,
+        "invoice_payload": "payload"
+      }
+    }))
+
+    bot.handle_update(update)
+
+    bot.handled_update.should eq("pre-checkout-id")
+  end
+end

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -102,7 +102,7 @@ module TelegramBot
       end
     end
 
-    def serve(bind_address : String = "127.0.0.1", bind_port : Int32 = 80, ssl_certificate_path : String | Nil = nil, ssl_key_path : String | Nil = nil)
+    def serve(bind_address : String = "127.0.0.1", bind_port : Int32 = 80, ssl_certificate_path : String? = nil, ssl_key_path : String? = nil)
       server = HTTP::Server.new do |context|
         begin
           Fiber.current.telegram_bot_server_http_context = context
@@ -206,7 +206,7 @@ module TelegramBot
       true
     end
 
-    protected def request(method : String, force_http : Bool = false, params : Hash = {} of String => String | Int32 | Nil)
+    protected def request(method : String, force_http : Bool = false, params : Hash = {} of String => String | Int32?)
       client = if !force_http && (context = Fiber.current.telegram_bot_server_http_context)
                  ResponseClient.new(context.not_nil!.response) ensure Fiber.current.telegram_bot_server_http_context = nil
                else
@@ -224,7 +224,7 @@ module TelegramBot
                  end
       client.close
 
-      return nil if response.nil?
+      return if response.nil?
       handle_http_response(response)
     end
 
@@ -293,7 +293,7 @@ module TelegramBot
       request {{ name }}, force_http: true, params: params
     end
 
-    alias ReplyMarkup = InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply | Nil
+    alias ReplyMarkup = InlineKeyboardMarkup | ReplyKeyboardMarkup | ReplyKeyboardRemove | ForceReply?
 
     def send_message(chat_id : Int | String,
                      text : String,
@@ -412,30 +412,30 @@ module TelegramBot
 
     def edit_message_live_location(latitude : Float,
                                    longitude : Float,
-                                   chat_id : Int | String | Nil = nil,
+                                   chat_id : Int | String? = nil,
                                    message_id : Int32? = nil,
                                    inline_message_id : String? = nil,
                                    reply_markup : ReplyMarkup? = nil)
       res = def_request "editMessageLiveLocation", chat_id, message_id, inline_message_id, latitude, longitude, reply_markup
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
 
-    def stop_message_live_location(chat_id : Int | String | Nil = nil,
+    def stop_message_live_location(chat_id : Int | String? = nil,
                                    message_id : Int32? = nil,
                                    inline_message_id : String? = nil,
                                    reply_markup : ReplyMarkup? = nil)
       res = def_request "stopMessageLiveLocation", chat_id, message_id, inline_message_id, reply_markup
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
@@ -598,60 +598,60 @@ module TelegramBot
       res.as_bool if res
     end
 
-    def edit_message_text(chat_id : Int | String | Nil = nil,
+    def edit_message_text(chat_id : Int | String? = nil,
                           message_id : Int32? = nil,
                           inline_message_id : String? = nil,
                           text : String? = nil,
                           parse_mode : String? = nil,
                           disable_web_page_preview : Bool? = nil,
-                          reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool | Nil
+                          reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool?
       res = def_request "editMessageText", chat_id, message_id, inline_message_id, text, parse_mode, disable_web_page_preview, reply_markup
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
 
-    def edit_message_caption(chat_id : Int | String | Nil = nil,
+    def edit_message_caption(chat_id : Int | String? = nil,
                              message_id : Int32? = nil,
                              inline_message_id : String? = nil,
                              caption : String? = nil,
-                             reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool | Nil
+                             reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool?
       res = def_request "editMessageCaption", chat_id, message_id, inline_message_id, caption, reply_markup
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
 
-    def edit_message_reply_markup(chat_id : Int | String | Nil = nil,
+    def edit_message_reply_markup(chat_id : Int | String? = nil,
                                   message_id : Int32? = nil,
                                   inline_message_id : String? = nil,
-                                  reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool | Nil
+                                  reply_markup : InlineKeyboardMarkup? = nil) : Message | Bool?
       res = def_request "editMessageReplyMarkup", chat_id, message_id, inline_message_id, reply_markup
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
 
     def delete_message(chat_id : Int | String,
-                       message_id : Int32) : Message | Bool | Nil
+                       message_id : Int32) : Message | Bool?
       res = def_request "deleteMessage", chat_id, message_id
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
@@ -686,7 +686,7 @@ module TelegramBot
       HTTP::Client.get("https://api.telegram.org/file/bot#{@token}/#{file_path}").body
     end
 
-    def set_webhook(url : String, certificate : ::File | String | Nil = nil, max_connections : Int32? = nil, allowed_updates : Array(String)? = @allowed_updates)
+    def set_webhook(url : String, certificate : ::File | String? = nil, max_connections : Int32? = nil, allowed_updates : Array(String)? = @allowed_updates)
       multipart_params = HTTP::Client::MultipartBody.new({"url" => url, "max_connections" => max_connections, "allowed_updates" => allowed_updates})
       multipart_params.add_file("certificate", certificate, filename: "cert.pem") if certificate
       Log.info { "Setting webhook to '#{url}'#{" with certificate" if certificate}" }
@@ -716,21 +716,21 @@ module TelegramBot
                        score : Int32,
                        force : Bool? = nil,
                        disable_edit_message : Bool? = nil,
-                       chat_id : Int | String | Nil = nil,
+                       chat_id : Int | String? = nil,
                        message_id : Int32? = nil,
-                       inline_message_id : String? = nil) : Message | Bool | Nil
+                       inline_message_id : String? = nil) : Message | Bool?
       res = def_request "setGameScore", user_id, score, force, disable_edit_message, chat_id, message_id, inline_message_id
       if res
         if res.as_bool?
-          return true
+          true
         else
-          return Message.from_json res.to_json
+          Message.from_json res.to_json
         end
       end
     end
 
     def get_game_high_scores(user_id : Int32,
-                             chat_id : Int | String | Nil = nil,
+                             chat_id : Int | String? = nil,
                              message_id : Int32? = nil,
                              inline_message_id : String? = nil) : Array(GameHighScore)
       res = def_request "getGameHighScores", user_id, chat_id, message_id, inline_message_id
@@ -772,14 +772,14 @@ module TelegramBot
     def answer_shipping_query(shipping_query_id : String,
                               ok : Bool,
                               shipping_options : Array(ShippingOption)? = nil,
-                              error_message : String? = nil) : Bool | Message | Nil
+                              error_message : String? = nil) : Bool | Message?
       res = def_request "answerShippingQuery", shipping_query_id, ok, shipping_options, error_message
       res.as_bool if res
     end
 
     def answer_pre_checkout_query(pre_checkout_query_id : String,
                                   ok : Bool,
-                                  error_message : String? = nil) : Bool | Message | Nil
+                                  error_message : String? = nil) : Bool | Message?
       res = def_request "answerPreCheckoutQuery", pre_checkout_query_id, ok, error_message
       res.as_bool if res
     end

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -48,6 +48,16 @@ module TelegramBot
       raise "callback_query handler is not implemented"
     end
 
+    # handle shipping query
+    def handle(shipping_query : ShippingQuery)
+      raise "shipping_query handler is not implemented"
+    end
+
+    # handle pre-checkout query
+    def handle(pre_checkout_query : PreCheckoutQuery)
+      raise "pre_checkout_query handler is not implemented"
+    end
+
     # @name username of the bot
     # @token
     # @allowlist
@@ -131,6 +141,12 @@ module TelegramBot
       elsif callback_query = u.callback_query
         return if !allowed_user?(callback_query)
         handle callback_query
+      elsif shipping_query = u.shipping_query
+        return if !allowed_user?(shipping_query)
+        handle shipping_query
+      elsif pre_checkout_query = u.pre_checkout_query
+        return if !allowed_user?(pre_checkout_query)
+        handle pre_checkout_query
       elsif message = u.edited_message
         return if !allowed_user?(message)
         handle_edited message
@@ -306,7 +322,7 @@ module TelegramBot
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
                    reply_markup : ReplyMarkup = nil) : Message?
-      res = def_request "sendPhoto", chat_id, photo, disable_notification, reply_to_message_id, reply_markup
+      res = def_request "sendPhoto", chat_id, photo, caption, disable_notification, reply_to_message_id, reply_markup
       Message.from_json res.to_json if res
     end
 
@@ -318,7 +334,7 @@ module TelegramBot
                    disable_notification : Bool? = nil,
                    reply_to_message_id : Int32? = nil,
                    reply_markup : ReplyMarkup = nil) : Message?
-      res = def_request "sendPhoto", chat_id, audio, duration, performer, title, disable_notification, reply_to_message_id, reply_markup
+      res = def_request "sendAudio", chat_id, audio, duration, performer, title, disable_notification, reply_to_message_id, reply_markup
       Message.from_json res.to_json if res
     end
 
@@ -371,7 +387,7 @@ module TelegramBot
                         disable_notification : Bool? = nil,
                         reply_to_message_id : Int32? = nil,
                         reply_markup : ReplyMarkup = nil) : Message?
-      res = def_request "sendVideoNote", chat_id, video, duration, length, disable_notification, caption, reply_to_message_id, reply_markup
+      res = def_request "sendVideoNote", chat_id, video_note, duration, length, disable_notification, reply_to_message_id, reply_markup
       Message.from_json res.to_json if res
     end
 
@@ -442,7 +458,8 @@ module TelegramBot
                      first_name : String,
                      last_name : String? = nil,
                      reply_to_message_id : Int32? = nil,
-                     reply_markup : ReplyMarkup = nil) : Message?
+                     reply_markup : ReplyMarkup = nil,
+                     disable_notification : Bool? = nil) : Message?
       res = def_request "sendContact", chat_id, phone_number, first_name, last_name, disable_notification, reply_to_message_id, reply_markup
       Message.from_json res.to_json if res
     end
@@ -536,18 +553,6 @@ module TelegramBot
     def get_chat(chat_id : Int | String)
       res = def_request "getChat", chat_id
       Chat.from_json res.not_nil!.to_json
-    end
-
-    def pin_chat_message(chat_id : Int | String,
-                         message_id : Int32,
-                         disable_notification : Bool?)
-      res = def_request "pinChatMessage", chat_id, message_id, disable_notification
-      res.as_bool if res
-    end
-
-    def unpin_chat_message(chat_id : Int | String)
-      res = def_request "unpinChatMessage", chat_id
-      res.as_bool if res
     end
 
     def leave_chat(chat_id : Int | String)
@@ -740,7 +745,7 @@ module TelegramBot
     #
 
     def send_invoice(chat_id : Int,
-                     tilte : String,
+                     title : String,
                      description : String,
                      payload : String,
                      provider_token : String,
@@ -760,15 +765,15 @@ module TelegramBot
                      disable_notification : Bool? = nil,
                      reply_to_message_id : Int32? = nil,
                      reply_markup : ReplyMarkup = nil) : Message?
-      res = def_request "sendInvoice", chat_id, tilte, description, payload, provider_token, start_parameter, currency, prices, photo_url, photo_size, photo_width, photo_height, need_name, need_phone_number, need_email, need_shipping_address, is_flexible, disable_notification, reply_to_message_id, reply_markup
+      res = def_request "sendInvoice", chat_id, title, description, payload, provider_token, start_parameter, currency, prices, photo_url, photo_size, photo_width, photo_height, need_name, need_phone_number, need_email, need_shipping_address, is_flexible, disable_notification, reply_to_message_id, reply_markup
       Message.from_json res.to_json if res
     end
 
     def answer_shipping_query(shipping_query_id : String,
                               ok : Bool,
-                              shipping_option : Array(ShippingOption)? = nil,
+                              shipping_options : Array(ShippingOption)? = nil,
                               error_message : String? = nil) : Bool | Message | Nil
-      res = def_request "answerShippingQuery", shipping_query_id, ok, shipping_option, error_message
+      res = def_request "answerShippingQuery", shipping_query_id, ok, shipping_options, error_message
       res.as_bool if res
     end
 

--- a/src/telegram_bot/http_client_multipart.cr
+++ b/src/telegram_bot/http_client_multipart.cr
@@ -1,19 +1,19 @@
 require "http/client"
 
 class HTTP::Client
-  def self.post_multipart(url : String | URI, parts : MultipartBody | Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+  def self.post_multipart(url : String | URI, parts : MultipartBody | Hash, headers : HTTP::Headers? = nil) : HTTP::Client::Response
     exec(url) do |client, path|
       client.post_multipart(path, parts, headers)
     end
   end
 
-  def post_multipart(path, parts : MultipartBody, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+  def post_multipart(path, parts : MultipartBody, headers : HTTP::Headers? = nil) : HTTP::Client::Response
     headers ||= HTTP::Headers.new
     headers["Content-Type"] = "multipart/form-data; boundary=#{parts.boundary}"
     post path, headers, parts.bodyg
   end
 
-  def post_multipart(path, params : Hash, headers : HTTP::Headers | Nil = nil) : HTTP::Client::Response
+  def post_multipart(path, params : Hash, headers : HTTP::Headers? = nil) : HTTP::Client::Response
     parts = HTTP::Client::MultipartBody.new(params)
     post_multipart(path, parts, headers)
   end


### PR DESCRIPTION
## Summary

- Fix incorrect request mappings for `send_photo`, `send_audio`, `send_video_note`, and `send_invoice`
- Add `disable_notification` support to `send_contact`
- Dispatch `shipping_query` and `pre_checkout_query` updates to handler hooks
- Fix `answer_shipping_query` to send `shipping_options`
- Remove duplicate chat pin/unpin wrapper definitions
- Add request-building specs for the fixed wrappers without calling Telegram