### PR TITLE
Request serialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,13 +24,13 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 1: Request Serialization Foundation
 
-- [ ] Add a shared helper for JSON-serializing API parameters that are arrays or
+- [x] Add a shared helper for JSON-serializing API parameters that are arrays or
       `JSON::Serializable` objects.
-- [ ] Ensure `allowed_updates`, media arrays, command arrays, inline results,
+- [x] Ensure `allowed_updates`, media arrays, command arrays, inline results,
       reply markup, and future object parameters are serialized consistently.
-- [ ] Decide whether to keep form-encoded requests as the default or introduce
+- [x] Decide whether to keep form-encoded requests as the default or introduce
       JSON request bodies for non-file requests.
-- [ ] Improve multipart handling enough for binary-safe file uploads.
+- [x] Improve multipart handling enough for binary-safe file uploads.
 
 ## Phase 2: Core Update Dispatch
 

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -126,9 +126,11 @@ describe TelegramBot::Bot do
     ])
     params = bot.serialize_for_spec({"reply_markup" => reply_markup})
 
-    JSON.parse(params["reply_markup"].as(String)).should eq(JSON.parse(%({
-      "inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]
-    })))
+    JSON.parse(params["reply_markup"].as(String)).should eq(JSON.parse(<<-JSON))
+      {
+        "inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]
+      }
+      JSON
   end
 
   it "serializes arrays of JSON objects" do
@@ -139,10 +141,12 @@ describe TelegramBot::Bot do
     ]
     params = bot.serialize_for_spec({"commands" => commands})
 
-    JSON.parse(params["commands"].as(String)).should eq(JSON.parse(%([
-      {"command": "start", "description": "Start the bot"},
-      {"command": "help", "description": "Show help"}
-    ])))
+    JSON.parse(params["commands"].as(String)).should eq(JSON.parse(<<-JSON))
+      [
+        {"command": "start", "description": "Start the bot"},
+        {"command": "help", "description": "Show help"}
+      ]
+      JSON
   end
 
   it "serializes inline query results through their base type" do
@@ -151,14 +155,16 @@ describe TelegramBot::Bot do
     results = [TelegramBot::InlineQueryResultArticle.new("article/1", "Article", content)] of TelegramBot::InlineQueryResult
     params = bot.serialize_for_spec({"results" => results})
 
-    JSON.parse(params["results"].as(String)).should eq(JSON.parse(%([
-      {
-        "type": "article",
-        "id": "article/1",
-        "title": "Article",
-        "input_message_content": {"message_text": "Article details"}
-      }
-    ])))
+    JSON.parse(params["results"].as(String)).should eq(JSON.parse(<<-JSON))
+      [
+        {
+          "type": "article",
+          "id": "article/1",
+          "title": "Article",
+          "input_message_content": {"message_text": "Article details"}
+        }
+      ]
+      JSON
   end
 
   it "keeps wrappers passing native arrays to the request layer" do

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -21,11 +21,15 @@ class RequestBuildingBot < TelegramBot::Bot
     end
 
     case method
-    when "answerShippingQuery", "answerPreCheckoutQuery", "pinChatMessage", "unpinChatMessage"
+    when "answerInlineQuery", "answerShippingQuery", "answerPreCheckoutQuery", "pinChatMessage", "unpinChatMessage", "setMyCommands"
       JSON.parse("true")
     else
       JSON.parse(%({"message_id":1,"date":0,"chat":{"id":1,"type":"private"}}))
     end
+  end
+
+  def serialize_for_spec(params : Hash)
+    serialize_params(params)
   end
 
   def handle(shipping_query : TelegramBot::ShippingQuery)
@@ -102,6 +106,90 @@ describe TelegramBot::Bot do
     bot.last_params["shipping_query_id"].should eq("query-id")
     bot.last_params["shipping_options"].should eq("[]")
     bot.last_params.has_key?("shipping_option").should be_false
+  end
+
+  it "serializes arrays and skips nil request params" do
+    bot = RequestBuildingBot.new
+    params = bot.serialize_for_spec({
+      "allowed_updates" => ["message", "callback_query"],
+      "timeout"         => nil,
+    })
+
+    params["allowed_updates"].should eq(%(["message","callback_query"]))
+    params.has_key?("timeout").should be_false
+  end
+
+  it "serializes JSON objects consistently" do
+    bot = RequestBuildingBot.new
+    reply_markup = TelegramBot::InlineKeyboardMarkup.new([
+      [TelegramBot::InlineKeyboardButton.new("Open", url: "https://example.com")],
+    ])
+    params = bot.serialize_for_spec({"reply_markup" => reply_markup})
+
+    JSON.parse(params["reply_markup"].as(String)).should eq(JSON.parse(%({
+      "inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]
+    })))
+  end
+
+  it "serializes arrays of JSON objects" do
+    bot = RequestBuildingBot.new
+    commands = [
+      TelegramBot::BotCommand.new("start", "Start the bot"),
+      TelegramBot::BotCommand.new("help", "Show help"),
+    ]
+    params = bot.serialize_for_spec({"commands" => commands})
+
+    JSON.parse(params["commands"].as(String)).should eq(JSON.parse(%([
+      {"command": "start", "description": "Start the bot"},
+      {"command": "help", "description": "Show help"}
+    ])))
+  end
+
+  it "serializes inline query results through their base type" do
+    bot = RequestBuildingBot.new
+    content = TelegramBot::InputTextMessageContent.new("Article details")
+    results = [TelegramBot::InlineQueryResultArticle.new("article/1", "Article", content)] of TelegramBot::InlineQueryResult
+    params = bot.serialize_for_spec({"results" => results})
+
+    JSON.parse(params["results"].as(String)).should eq(JSON.parse(%([
+      {
+        "type": "article",
+        "id": "article/1",
+        "title": "Article",
+        "input_message_content": {"message_text": "Article details"}
+      }
+    ])))
+  end
+
+  it "keeps wrappers passing native arrays to the request layer" do
+    bot = RequestBuildingBot.new
+    content = TelegramBot::InputTextMessageContent.new("Article details")
+    results = [TelegramBot::InlineQueryResultArticle.new("article/1", "Article", content)] of TelegramBot::InlineQueryResult
+
+    bot.answer_inline_query("inline-query-id", results)
+
+    bot.last_method.should eq("answerInlineQuery")
+    if results_param = bot.last_params["results"]?
+      results_param.should contain("InlineQueryResultArticle")
+    else
+      fail "expected results param"
+    end
+  end
+
+  it "builds multipart bodies with serialized non-file params" do
+    body = HTTP::Client::MultipartBody.new({"allowed_updates" => %(["message"])})
+
+    body.content_type.should contain("multipart/form-data")
+    body.bodyg.should contain(%(["message"]))
+  end
+
+  it "builds multipart file parts without manual header assembly" do
+    body = HTTP::Client::MultipartBody.new
+    body.add_file("document", "binary\u0000content", filename: "file.bin")
+    payload = body.bodyg
+
+    payload.should contain(%(name="document"; filename="file.bin"))
+    payload.should contain("binary\u0000content")
   end
 
   it "dispatches shipping queries" do

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -213,12 +213,14 @@ module TelegramBot
                  HttpClient.new(@token)
                end
 
-      response = if params.values.any?(::IO::FileDescriptor)
-                   multipart_params = HTTP::Client::MultipartBody.new(params)
+      serialized_params = serialize_params(params)
+
+      response = if serialized_params.values.any?(::File)
+                   multipart_params = HTTP::Client::MultipartBody.new(serialized_params)
                    client.post_multipart method, multipart_params
-                 elsif !params.empty?
-                   stringified_params = params.reduce(Hash(String, String).new) { |h, (k, v)| h[k] = v.to_s; h }
-                   client.post_form method, stringified_params
+                 elsif !serialized_params.empty?
+                   form_params = serialized_params.reduce(Hash(String, String).new) { |h, (k, v)| h[k] = v.to_s; h }
+                   client.post_form method, form_params
                  else
                    client.post method
                  end
@@ -226,6 +228,40 @@ module TelegramBot
 
       return if response.nil?
       handle_http_response(response)
+    end
+
+    protected def serialize_params(params : Hash) : Hash(String, String | ::File)
+      params.reduce(Hash(String, String | ::File).new) do |serialized, (key, value)|
+        unless value.nil?
+          serialized[key] = serialize_param(value)
+        end
+
+        serialized
+      end
+    end
+
+    protected def serialize_param(value : ::File) : ::File
+      value
+    end
+
+    protected def serialize_param(value : String) : String
+      value
+    end
+
+    protected def serialize_param(value : Bool) : String
+      value.to_s
+    end
+
+    protected def serialize_param(value : Number) : String
+      value.to_s
+    end
+
+    protected def serialize_param(value : Array) : String
+      value.to_json
+    end
+
+    protected def serialize_param(value) : String
+      value.to_json
     end
 
     protected def handle_http_response(response)
@@ -268,11 +304,7 @@ module TelegramBot
     macro def_request(name, *args)
       params = {
         {% for arg in args %}
-          {% if arg.stringify == "reply_markup" %}
-            {{ arg.stringify }} => {{ arg.id }}.try(&.to_json),
-          {% else %}
-            {{ arg.stringify }} => {{ arg.id }},
-          {% end %}
+          {{ arg.stringify }} => {{ arg.id }},
         {% end %}
       }
 
@@ -282,11 +314,7 @@ module TelegramBot
     macro def_force_request(name, *args)
       params = {
         {% for arg in args %}
-          {% if arg.stringify == "reply_markup" %}
-            {{ arg.stringify }} => {{ arg.id }}.try(&.to_json),
-          {% else %}
-            {{ arg.stringify }} => {{ arg.id }},
-          {% end %}
+          {{ arg.stringify }} => {{ arg.id }},
         {% end %}
       }
 
@@ -664,7 +692,6 @@ module TelegramBot
                             switch_pm_text : String? = nil,
                             switch_pm_parameter : String? = nil) : Bool?
       # results   Array of InlineQueryResult  Yes   A JSON-serialized array of results for the inline query
-      results = "[" + results.join(", ", &.to_json) + "]"
       res = def_request "answerInlineQuery", inline_query_id, cache_time, is_personal, next_offset, results, switch_pm_text, switch_pm_parameter
       res.as_bool if res
     end
@@ -687,7 +714,7 @@ module TelegramBot
     end
 
     def set_webhook(url : String, certificate : ::File | String? = nil, max_connections : Int32? = nil, allowed_updates : Array(String)? = @allowed_updates)
-      multipart_params = HTTP::Client::MultipartBody.new({"url" => url, "max_connections" => max_connections, "allowed_updates" => allowed_updates})
+      multipart_params = HTTP::Client::MultipartBody.new(serialize_params({"url" => url, "max_connections" => max_connections, "allowed_updates" => allowed_updates}))
       multipart_params.add_file("certificate", certificate, filename: "cert.pem") if certificate
       Log.info { "Setting webhook to '#{url}'#{" with certificate" if certificate}" }
       response = HttpClient.new(@token).post_multipart "setWebhook", multipart_params
@@ -805,7 +832,6 @@ module TelegramBot
                                emojis : String,
                                contains_masks : Bool? = nil,
                                mask_position : MaskPosition? = nil)
-      mask_position = mask_position.to_json
       res = def_request "createNewStickerSet", user_id, name, title, png_sticker, emojis, contains_masks, mask_position
       res.as_bool if res
     end
@@ -815,7 +841,6 @@ module TelegramBot
                            png_sticker : ::File | String,
                            emojis : String,
                            mask_position : MaskPosition? = nil)
-      mask_position = mask_position.to_json
       res = def_request "addStickerToSet", user_id, name, png_sticker, emojis, mask_position
       res.as_bool if res
     end
@@ -841,7 +866,6 @@ module TelegramBot
 
     # Change the list of the bot's commands.
     def set_my_commands(commands : Array(BotCommand))
-      commands = "[" + commands.join(", ", &.to_json) + "]"
       res = def_request "setMyCommands", commands
       res.as_bool if res
     end

--- a/src/telegram_bot/http_client_multipart.cr
+++ b/src/telegram_bot/http_client_multipart.cr
@@ -1,4 +1,5 @@
 require "http/client"
+require "http/formdata"
 
 class HTTP::Client
   def self.post_multipart(url : String | URI, parts : MultipartBody | Hash, headers : HTTP::Headers? = nil) : HTTP::Client::Response
@@ -9,7 +10,7 @@ class HTTP::Client
 
   def post_multipart(path, parts : MultipartBody, headers : HTTP::Headers? = nil) : HTTP::Client::Response
     headers ||= HTTP::Headers.new
-    headers["Content-Type"] = "multipart/form-data; boundary=#{parts.boundary}"
+    headers["Content-Type"] = parts.content_type
     post path, headers, parts.bodyg
   end
 
@@ -18,21 +19,35 @@ class HTTP::Client
     post_multipart(path, parts, headers)
   end
 
-  # ugly represation of multipart/from-data (works for now)
   class MultipartBody
-    getter boundary
-
-    @boundary : String = Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s + Random.rand(999999).to_s
-    @body : String = ""
-
-    def bodyg
-      @body + "--" + @boundary + "--\r\n"
-    end
+    @body = IO::Memory.new
+    @builder : HTTP::FormData::Builder
+    @finished = false
 
     def initialize
+      @builder = HTTP::FormData::Builder.new(@body)
+    end
+
+    def boundary
+      @builder.boundary
+    end
+
+    def content_type
+      @builder.content_type
+    end
+
+    def bodyg
+      unless @finished
+        @builder.finish
+        @finished = true
+      end
+
+      @body.to_s
     end
 
     def initialize(params : Hash)
+      initialize
+
       params.each do |k, v|
         if v.nil?
           next
@@ -45,27 +60,24 @@ class HTTP::Client
     end
 
     def add_part(name : String, content : String, mime_type : String? = nil)
-      @body += "--" + @boundary + "\r\n"
-      @body += "Content-Disposition: form-data; name=\"#{name}\"\r\n"
-      if mime_type
-        @body += "Content-Type: #{mime_type}\r\n"
-      end
-      @body += "\r\n" + content + "\r\n"
+      headers = HTTP::Headers.new
+      headers["Content-Type"] = mime_type if mime_type
+      @builder.field(name, content, headers)
     end
 
     def add_file(name : String, content : String, filename : String? = nil, mime_type : String = "application/octet-stream")
-      @body += "--" + @boundary + "\r\n"
-      @body += "Content-Disposition: form-data; name=\"#{name}\"; filename=\"#{filename}\"\r\n"
-      if mime_type
-        @body += "Content-Type: #{mime_type}\r\n"
-      end
-
-      @body += "\r\n" + content + "\r\n"
+      headers = HTTP::Headers{"Content-Type" => mime_type}
+      metadata = HTTP::FormData::FileMetadata.new(filename: filename)
+      @builder.file(name, IO::Memory.new(content), metadata, headers)
     end
 
     def add_file(name : String, file : ::File, filename : String? = nil, mime_type : String = "application/octet-stream")
-      content = File.read(file.path)
-      add_file(name, content, filename || file.path, mime_type)
+      headers = HTTP::Headers{"Content-Type" => mime_type}
+      metadata = HTTP::FormData::FileMetadata.new(filename: filename || ::File.basename(file.path))
+
+      ::File.open(file.path) do |io|
+        @builder.file(name, io, metadata, headers)
+      end
     end
   end
 end

--- a/src/telegram_bot/response_client.cr
+++ b/src/telegram_bot/response_client.cr
@@ -20,7 +20,7 @@ module TelegramBot
 
     def post_multipart(method : String, multipart_body : HTTP::Client::MultipartBody)
       multipart_body.add_part("method", method)
-      @response.content_type = "multipart/form-data; boundary=#{multipart_body.boundary}"
+      @response.content_type = multipart_body.content_type
       @response.print(multipart_body.bodyg)
       nil
     end

--- a/src/telegram_bot/types/inline/inline_query_result.cr
+++ b/src/telegram_bot/types/inline/inline_query_result.cr
@@ -1,4 +1,7 @@
 module TelegramBot
   abstract class InlineQueryResult
+    def to_json(json : JSON::Builder)
+      raise "InlineQueryResult subclasses must implement JSON serialization"
+    end
   end
 end

--- a/src/telegram_bot/types/input_media.cr
+++ b/src/telegram_bot/types/input_media.cr
@@ -1,4 +1,7 @@
 module TelegramBot
   class InputMedia
+    def to_json(json : JSON::Builder)
+      raise "InputMedia subclasses must implement JSON serialization"
+    end
   end
 end

--- a/src/telegram_bot/types/input_message_content.cr
+++ b/src/telegram_bot/types/input_message_content.cr
@@ -1,4 +1,7 @@
 module TelegramBot
   abstract class InputMessageContent
+    def to_json(json : JSON::Builder)
+      raise "InputMessageContent subclasses must implement JSON serialization"
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Add centralized request parameter serialization for Telegram API calls
- Serialize arrays and JSON objects consistently with `to_json`
- Preserve files as multipart file values and skip nil params
- Remove manual JSON string assembly from inline query results, bot commands, reply markup, and sticker mask positions
- Keep form-encoded requests as the default for non-file requests
- Replace manual multipart body construction with Crystal's `HTTP::FormData::Builder`
- Add base `to_json` hooks for `InlineQueryResult`, `InputMessageContent`, and `InputMedia`
- Add focused request-building specs for serialization and multipart behavior