### PR TITLE
Add modern Telegram update dispatch

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,28 +34,28 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 2: Core Update Dispatch
 
-- [ ] Add missing `Update` fields:
-  - [ ] `shipping_query`
-  - [ ] `pre_checkout_query`
-  - [ ] `poll`
-  - [ ] `poll_answer`
-  - [ ] `my_chat_member`
-  - [ ] `chat_member`
-  - [ ] `chat_join_request`
-  - [ ] `message_reaction`
-  - [ ] `message_reaction_count`
-  - [ ] `business_connection`
-  - [ ] `business_message`
-  - [ ] `edited_business_message`
-  - [ ] `deleted_business_messages`
-  - [ ] `purchased_paid_media`
-  - [ ] `chat_boost`
-  - [ ] `removed_chat_boost`
-  - [ ] `guest_message`
-  - [ ] `managed_bot`
-- [ ] Add overridable handler methods for the update types above.
-- [ ] Update `handle_update` to dispatch all supported update fields.
-- [ ] Keep existing handler behavior backward-compatible.
+- [x] Add missing `Update` fields:
+  - [x] `shipping_query`
+  - [x] `pre_checkout_query`
+  - [x] `poll`
+  - [x] `poll_answer`
+  - [x] `my_chat_member`
+  - [x] `chat_member`
+  - [x] `chat_join_request`
+  - [x] `message_reaction`
+  - [x] `message_reaction_count`
+  - [x] `business_connection`
+  - [x] `business_message`
+  - [x] `edited_business_message`
+  - [x] `deleted_business_messages`
+  - [x] `purchased_paid_media`
+  - [x] `chat_boost`
+  - [x] `removed_chat_boost`
+  - [x] `guest_message`
+  - [x] `managed_bot`
+- [x] Add overridable handler methods for the update types above.
+- [x] Update `handle_update` to dispatch all supported update fields.
+- [x] Keep existing handler behavior backward-compatible.
 
 ## Phase 3: Modern Core Message Types
 

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -39,6 +39,70 @@ class RequestBuildingBot < TelegramBot::Bot
   def handle(pre_checkout_query : TelegramBot::PreCheckoutQuery)
     @handled_update = pre_checkout_query.id
   end
+
+  def handle_business_connection(business_connection : TelegramBot::BusinessConnection)
+    @handled_update = business_connection.id
+  end
+
+  def handle_business_message(message : TelegramBot::Message)
+    @handled_update = "business_message:#{message.message_id}"
+  end
+
+  def handle_edited_business_message(message : TelegramBot::Message)
+    @handled_update = "edited_business_message:#{message.message_id}"
+  end
+
+  def handle_deleted_business_messages(deleted_business_messages : TelegramBot::BusinessMessagesDeleted)
+    @handled_update = deleted_business_messages.business_connection_id
+  end
+
+  def handle_guest_message(message : TelegramBot::Message)
+    @handled_update = "guest_message:#{message.message_id}"
+  end
+
+  def handle(message_reaction : TelegramBot::MessageReactionUpdated)
+    @handled_update = "message_reaction:#{message_reaction.message_id}"
+  end
+
+  def handle(message_reaction_count : TelegramBot::MessageReactionCountUpdated)
+    @handled_update = "message_reaction_count:#{message_reaction_count.message_id}"
+  end
+
+  def handle(purchased_paid_media : TelegramBot::PaidMediaPurchased)
+    @handled_update = purchased_paid_media.paid_media_payload
+  end
+
+  def handle(poll : TelegramBot::Poll)
+    @handled_update = poll.id
+  end
+
+  def handle(poll_answer : TelegramBot::PollAnswer)
+    @handled_update = poll_answer.poll_id
+  end
+
+  def handle_my_chat_member(my_chat_member : TelegramBot::ChatMemberUpdated)
+    @handled_update = "my_chat_member:#{my_chat_member.date}"
+  end
+
+  def handle(chat_member : TelegramBot::ChatMemberUpdated)
+    @handled_update = "chat_member:#{chat_member.date}"
+  end
+
+  def handle(chat_join_request : TelegramBot::ChatJoinRequest)
+    @handled_update = "chat_join_request:#{chat_join_request.user_chat_id}"
+  end
+
+  def handle(chat_boost : TelegramBot::ChatBoostUpdated)
+    @handled_update = chat_boost.boost.try(&.boost_id)
+  end
+
+  def handle(removed_chat_boost : TelegramBot::ChatBoostRemoved)
+    @handled_update = removed_chat_boost.boost_id
+  end
+
+  def handle(managed_bot : TelegramBot::ManagedBotUpdated)
+    @handled_update = managed_bot.bot.try(&.username)
+  end
 end
 
 describe TelegramBot::Bot do
@@ -242,5 +306,223 @@ describe TelegramBot::Bot do
     bot.handle_update(update)
 
     bot.handled_update.should eq("pre-checkout-id")
+  end
+
+  it "dispatches modern update fields" do
+    cases = {
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "business_connection": {"id": "business-connection-id"}
+          }
+          JSON
+        "business-connection-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "business_message": {"message_id": 10, "date": 0, "chat": {"id": 1, "type": "private"}}
+          }
+          JSON
+        "business_message:10",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "edited_business_message": {"message_id": 11, "date": 0, "chat": {"id": 1, "type": "private"}}
+          }
+          JSON
+        "edited_business_message:11",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "deleted_business_messages": {
+              "business_connection_id": "deleted-business-id",
+              "chat": {"id": 1, "type": "private"},
+              "message_ids": [1, 2]
+            }
+          }
+          JSON
+        "deleted-business-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "guest_message": {"message_id": 12, "date": 0, "chat": {"id": 1, "type": "private"}}
+          }
+          JSON
+        "guest_message:12",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "message_reaction": {
+              "chat": {"id": 1, "type": "private"},
+              "message_id": 13,
+              "date": 0,
+              "old_reaction": [],
+              "new_reaction": []
+            }
+          }
+          JSON
+        "message_reaction:13",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "message_reaction_count": {
+              "chat": {"id": 1, "type": "private"},
+              "message_id": 14,
+              "date": 0,
+              "reactions": []
+            }
+          }
+          JSON
+        "message_reaction_count:14",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "purchased_paid_media": {
+              "from": {"id": 1, "is_bot": false, "first_name": "User"},
+              "paid_media_payload": "paid-media-payload"
+            }
+          }
+          JSON
+        "paid-media-payload",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "poll": {
+              "id": "poll-id",
+              "question": "Question?",
+              "options": [],
+              "total_voter_count": 0,
+              "is_closed": false,
+              "is_anonymous": false,
+              "type": "regular",
+              "allows_multiple_answers": false
+            }
+          }
+          JSON
+        "poll-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "poll_answer": {
+              "poll_id": "poll-answer-id",
+              "user": {"id": 1, "is_bot": false, "first_name": "User"},
+              "option_ids": [0]
+            }
+          }
+          JSON
+        "poll-answer-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "my_chat_member": {
+              "chat": {"id": 1, "type": "private"},
+              "from": {"id": 1, "is_bot": false, "first_name": "User"},
+              "date": 15,
+              "old_chat_member": {"user": {"id": 2, "is_bot": true, "first_name": "Bot"}, "status": "member"},
+              "new_chat_member": {"user": {"id": 2, "is_bot": true, "first_name": "Bot"}, "status": "administrator"}
+            }
+          }
+          JSON
+        "my_chat_member:15",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "chat_member": {
+              "chat": {"id": 1, "type": "private"},
+              "from": {"id": 1, "is_bot": false, "first_name": "User"},
+              "date": 16,
+              "old_chat_member": {"user": {"id": 3, "is_bot": false, "first_name": "Member"}, "status": "member"},
+              "new_chat_member": {"user": {"id": 3, "is_bot": false, "first_name": "Member"}, "status": "left"}
+            }
+          }
+          JSON
+        "chat_member:16",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "chat_join_request": {
+              "chat": {"id": 1, "type": "private"},
+              "from": {"id": 1, "is_bot": false, "first_name": "User"},
+              "user_chat_id": 12345,
+              "date": 0
+            }
+          }
+          JSON
+        "chat_join_request:12345",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "chat_boost": {
+              "chat": {"id": 1, "type": "private"},
+              "boost": {
+                "boost_id": "boost-id",
+                "add_date": 0,
+                "expiration_date": 1,
+                "source": {"source": "premium", "user": {"id": 1, "is_bot": false, "first_name": "User"}}
+              }
+            }
+          }
+          JSON
+        "boost-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "removed_chat_boost": {
+              "chat": {"id": 1, "type": "private"},
+              "boost_id": "removed-boost-id",
+              "remove_date": 0,
+              "source": {"source": "premium", "user": {"id": 1, "is_bot": false, "first_name": "User"}}
+            }
+          }
+          JSON
+        "removed-boost-id",
+      },
+      {
+        <<-JSON,
+          {
+            "update_id": 1,
+            "managed_bot": {
+              "bot": {"id": 2, "is_bot": true, "first_name": "Managed", "username": "managed_bot"}
+            }
+          }
+          JSON
+        "managed_bot",
+      },
+    }
+
+    cases.each do |json, expected|
+      bot = RequestBuildingBot.new
+      bot.handle_update(TelegramBot::Update.from_json(json))
+      bot.handled_update.should eq(expected)
+    end
   end
 end

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -48,6 +48,41 @@ module TelegramBot
       raise "callback_query handler is not implemented"
     end
 
+    # handle business connection updates
+    def handle_business_connection(business_connection : BusinessConnection)
+      raise "business_connection handler is not implemented"
+    end
+
+    # handle business messages
+    def handle_business_message(message : Message)
+      raise "business_message handler is not implemented"
+    end
+
+    # handle edited business messages
+    def handle_edited_business_message(message : Message)
+      raise "edited_business_message handler is not implemented"
+    end
+
+    # handle deleted business messages
+    def handle_deleted_business_messages(deleted_business_messages : BusinessMessagesDeleted)
+      raise "deleted_business_messages handler is not implemented"
+    end
+
+    # handle guest messages
+    def handle_guest_message(message : Message)
+      raise "guest_message handler is not implemented"
+    end
+
+    # handle message reaction updates
+    def handle(message_reaction : MessageReactionUpdated)
+      raise "message_reaction handler is not implemented"
+    end
+
+    # handle message reaction count updates
+    def handle(message_reaction_count : MessageReactionCountUpdated)
+      raise "message_reaction_count handler is not implemented"
+    end
+
     # handle shipping query
     def handle(shipping_query : ShippingQuery)
       raise "shipping_query handler is not implemented"
@@ -56,6 +91,51 @@ module TelegramBot
     # handle pre-checkout query
     def handle(pre_checkout_query : PreCheckoutQuery)
       raise "pre_checkout_query handler is not implemented"
+    end
+
+    # handle purchased paid media updates
+    def handle(purchased_paid_media : PaidMediaPurchased)
+      raise "purchased_paid_media handler is not implemented"
+    end
+
+    # handle poll updates
+    def handle(poll : Poll)
+      raise "poll handler is not implemented"
+    end
+
+    # handle poll answer updates
+    def handle(poll_answer : PollAnswer)
+      raise "poll_answer handler is not implemented"
+    end
+
+    # handle bot chat member status updates
+    def handle_my_chat_member(my_chat_member : ChatMemberUpdated)
+      raise "my_chat_member handler is not implemented"
+    end
+
+    # handle chat member status updates
+    def handle(chat_member : ChatMemberUpdated)
+      raise "chat_member handler is not implemented"
+    end
+
+    # handle chat join requests
+    def handle(chat_join_request : ChatJoinRequest)
+      raise "chat_join_request handler is not implemented"
+    end
+
+    # handle chat boost updates
+    def handle(chat_boost : ChatBoostUpdated)
+      raise "chat_boost handler is not implemented"
+    end
+
+    # handle removed chat boost updates
+    def handle(removed_chat_boost : ChatBoostRemoved)
+      raise "removed_chat_boost handler is not implemented"
+    end
+
+    # handle managed bot updates
+    def handle(managed_bot : ManagedBotUpdated)
+      raise "managed_bot handler is not implemented"
     end
 
     # @name username of the bot
@@ -141,12 +221,47 @@ module TelegramBot
       elsif callback_query = u.callback_query
         return if !allowed_user?(callback_query)
         handle callback_query
+      elsif business_connection = u.business_connection
+        handle_business_connection business_connection
+      elsif message = u.business_message
+        return if !allowed_user?(message)
+        handle_business_message message
+      elsif message = u.edited_business_message
+        return if !allowed_user?(message)
+        handle_edited_business_message message
+      elsif deleted_business_messages = u.deleted_business_messages
+        handle_deleted_business_messages deleted_business_messages
+      elsif message = u.guest_message
+        return if !allowed_user?(message)
+        handle_guest_message message
+      elsif message_reaction = u.message_reaction
+        handle message_reaction
+      elsif message_reaction_count = u.message_reaction_count
+        handle message_reaction_count
       elsif shipping_query = u.shipping_query
         return if !allowed_user?(shipping_query)
         handle shipping_query
       elsif pre_checkout_query = u.pre_checkout_query
         return if !allowed_user?(pre_checkout_query)
         handle pre_checkout_query
+      elsif purchased_paid_media = u.purchased_paid_media
+        handle purchased_paid_media
+      elsif poll = u.poll
+        handle poll
+      elsif poll_answer = u.poll_answer
+        handle poll_answer
+      elsif my_chat_member = u.my_chat_member
+        handle_my_chat_member my_chat_member
+      elsif chat_member = u.chat_member
+        handle chat_member
+      elsif chat_join_request = u.chat_join_request
+        handle chat_join_request
+      elsif chat_boost = u.chat_boost
+        handle chat_boost
+      elsif removed_chat_boost = u.removed_chat_boost
+        handle removed_chat_boost
+      elsif managed_bot = u.managed_bot
+        handle managed_bot
       elsif message = u.edited_message
         return if !allowed_user?(message)
         handle_edited message

--- a/src/telegram_bot/types/business_connection.cr
+++ b/src/telegram_bot/types/business_connection.cr
@@ -1,0 +1,12 @@
+module TelegramBot
+  class BusinessConnection
+    include JSON::Serializable
+
+    property id : String?
+    property user : User?
+    property user_chat_id : Int64?
+    property date : Int32?
+    property? can_reply : Bool?
+    property? is_enabled : Bool?
+  end
+end

--- a/src/telegram_bot/types/business_messages_deleted.cr
+++ b/src/telegram_bot/types/business_messages_deleted.cr
@@ -1,0 +1,9 @@
+module TelegramBot
+  class BusinessMessagesDeleted
+    include JSON::Serializable
+
+    property business_connection_id : String?
+    property chat : Chat?
+    property message_ids : Array(Int32)?
+  end
+end

--- a/src/telegram_bot/types/chat_boost.cr
+++ b/src/telegram_bot/types/chat_boost.cr
@@ -1,0 +1,26 @@
+module TelegramBot
+  class ChatBoost
+    include JSON::Serializable
+
+    property boost_id : String?
+    property add_date : Int32?
+    property expiration_date : Int32?
+    property source : JSON::Any?
+  end
+
+  class ChatBoostUpdated
+    include JSON::Serializable
+
+    property chat : Chat?
+    property boost : ChatBoost?
+  end
+
+  class ChatBoostRemoved
+    include JSON::Serializable
+
+    property chat : Chat?
+    property boost_id : String?
+    property remove_date : Int32?
+    property source : JSON::Any?
+  end
+end

--- a/src/telegram_bot/types/chat_join_request.cr
+++ b/src/telegram_bot/types/chat_join_request.cr
@@ -1,0 +1,12 @@
+module TelegramBot
+  class ChatJoinRequest
+    include JSON::Serializable
+
+    property chat : Chat?
+    property from : User?
+    property user_chat_id : Int64?
+    property date : Int32?
+    property bio : String?
+    property invite_link : JSON::Any?
+  end
+end

--- a/src/telegram_bot/types/chat_member_updated.cr
+++ b/src/telegram_bot/types/chat_member_updated.cr
@@ -1,0 +1,14 @@
+module TelegramBot
+  class ChatMemberUpdated
+    include JSON::Serializable
+
+    property chat : Chat?
+    property from : User?
+    property date : Int32?
+    property old_chat_member : ChatMember?
+    property new_chat_member : ChatMember?
+    property invite_link : JSON::Any?
+    property? via_join_request : Bool?
+    property? via_chat_folder_invite_link : Bool?
+  end
+end

--- a/src/telegram_bot/types/managed_bot_updated.cr
+++ b/src/telegram_bot/types/managed_bot_updated.cr
@@ -1,0 +1,12 @@
+module TelegramBot
+  class ManagedBotUpdated
+    include JSON::Serializable
+
+    property bot : User?
+    property manager_bot : User?
+    property user : User?
+    property date : Int32?
+    property old_token : String?
+    property new_token : String?
+  end
+end

--- a/src/telegram_bot/types/message_reaction_updated.cr
+++ b/src/telegram_bot/types/message_reaction_updated.cr
@@ -1,0 +1,29 @@
+module TelegramBot
+  class MessageReactionUpdated
+    include JSON::Serializable
+
+    property chat : Chat?
+    property message_id : Int32?
+    property user : User?
+    property actor_chat : Chat?
+    property date : Int32?
+    property old_reaction : Array(JSON::Any)?
+    property new_reaction : Array(JSON::Any)?
+  end
+
+  class ReactionCount
+    include JSON::Serializable
+
+    property type : JSON::Any?
+    property total_count : Int32?
+  end
+
+  class MessageReactionCountUpdated
+    include JSON::Serializable
+
+    property chat : Chat?
+    property message_id : Int32?
+    property date : Int32?
+    property reactions : Array(ReactionCount)?
+  end
+end

--- a/src/telegram_bot/types/paid_media_purchased.cr
+++ b/src/telegram_bot/types/paid_media_purchased.cr
@@ -1,0 +1,8 @@
+module TelegramBot
+  class PaidMediaPurchased
+    include JSON::Serializable
+
+    property from : User?
+    property paid_media_payload : String?
+  end
+end

--- a/src/telegram_bot/types/poll.cr
+++ b/src/telegram_bot/types/poll.cr
@@ -1,0 +1,40 @@
+module TelegramBot
+  class PollOption
+    include JSON::Serializable
+
+    property text : String?
+    property text_entities : Array(MessageEntity)?
+    property voter_count : Int32?
+    property persistent_id : String?
+    property added_by_user : User?
+    property added_by_chat : Chat?
+    property addition_date : Int32?
+    property media : JSON::Any?
+  end
+
+  class Poll
+    include JSON::Serializable
+
+    property id : String?
+    property question : String?
+    property question_entities : Array(MessageEntity)?
+    property options : Array(PollOption)?
+    property total_voter_count : Int32?
+    property? is_closed : Bool?
+    property? is_anonymous : Bool?
+    property type : String?
+    property? allows_multiple_answers : Bool?
+    property correct_option_ids : Array(Int32)?
+    property explanation : String?
+    property explanation_entities : Array(MessageEntity)?
+    property open_period : Int32?
+    property close_date : Int32?
+    property? allows_revoting : Bool?
+    property description : String?
+    property description_entities : Array(MessageEntity)?
+    property media : JSON::Any?
+    property explanation_media : JSON::Any?
+    property? members_only : Bool?
+    property country_codes : Array(String)?
+  end
+end

--- a/src/telegram_bot/types/poll_answer.cr
+++ b/src/telegram_bot/types/poll_answer.cr
@@ -1,0 +1,11 @@
+module TelegramBot
+  class PollAnswer
+    include JSON::Serializable
+
+    property poll_id : String?
+    property voter_chat : Chat?
+    property user : User?
+    property option_ids : Array(Int32)?
+    property option_persistent_ids : Array(String)?
+  end
+end

--- a/src/telegram_bot/types/update.cr
+++ b/src/telegram_bot/types/update.cr
@@ -7,10 +7,26 @@ module TelegramBot
     property edited_message : TelegramBot::Message?
     property channel_post : TelegramBot::Message?
     property edited_channel_post : TelegramBot::Message?
+    property business_connection : TelegramBot::BusinessConnection?
+    property business_message : TelegramBot::Message?
+    property edited_business_message : TelegramBot::Message?
+    property deleted_business_messages : TelegramBot::BusinessMessagesDeleted?
+    property guest_message : TelegramBot::Message?
+    property message_reaction : TelegramBot::MessageReactionUpdated?
+    property message_reaction_count : TelegramBot::MessageReactionCountUpdated?
     property inline_query : TelegramBot::InlineQuery?
     property chosen_inline_result : TelegramBot::ChosenInlineResult?
     property callback_query : TelegramBot::CallbackQuery?
     property shipping_query : TelegramBot::ShippingQuery?
     property pre_checkout_query : TelegramBot::PreCheckoutQuery?
+    property purchased_paid_media : TelegramBot::PaidMediaPurchased?
+    property poll : TelegramBot::Poll?
+    property poll_answer : TelegramBot::PollAnswer?
+    property my_chat_member : TelegramBot::ChatMemberUpdated?
+    property chat_member : TelegramBot::ChatMemberUpdated?
+    property chat_join_request : TelegramBot::ChatJoinRequest?
+    property chat_boost : TelegramBot::ChatBoostUpdated?
+    property removed_chat_boost : TelegramBot::ChatBoostRemoved?
+    property managed_bot : TelegramBot::ManagedBotUpdated?
   end
 end


### PR DESCRIPTION
## Summary

- Add modern `Update` fields for business, guest, reaction, poll, chat member, join request, boost, paid media, and managed bot updates
- Add overridable handler hooks for the new update types
- Update `handle_update` to dispatch all supported update fields
- Add minimal parse-safe DTOs needed by the new update fields
- Add focused dispatch coverage for the new update types