### PR TITLE
Add modern Telegram message type fields

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -59,45 +59,45 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 3: Modern Core Message Types
 
-- [ ] Add or update shared message-related types:
-  - [ ] `MessageId`
-  - [ ] `InaccessibleMessage`
-  - [ ] `MaybeInaccessibleMessage`
-  - [ ] `ReplyParameters`
-  - [ ] `TextQuote`
-  - [ ] `ExternalReplyInfo`
-  - [ ] `LinkPreviewOptions`
-  - [ ] `MessageOriginUser`
-  - [ ] `MessageOriginHiddenUser`
-  - [ ] `MessageOriginChat`
-  - [ ] `MessageOriginChannel`
-- [ ] Expand `Message` with common modern fields:
-  - [ ] `message_thread_id`
-  - [ ] `direct_messages_topic`
-  - [ ] `sender_chat`
-  - [ ] `sender_boost_count`
-  - [ ] `sender_business_bot`
-  - [ ] `business_connection_id`
-  - [ ] `forward_origin`
-  - [ ] `is_topic_message`
-  - [ ] `is_automatic_forward`
-  - [ ] `reply_to_message`
-  - [ ] `external_reply`
-  - [ ] `quote`
-  - [ ] `reply_to_story`
-  - [ ] `reply_to_checklist_task_id`
-  - [ ] `reply_to_poll_option_id`
-  - [ ] `has_protected_content`
-  - [ ] `is_from_offline`
-  - [ ] `is_paid_post`
-  - [ ] `paid_star_count`
-  - [ ] `effect_id`
-  - [ ] `show_caption_above_media`
-  - [ ] `has_media_spoiler`
-  - [ ] `reply_markup`
-- [ ] Expand `MessageEntity` with modern fields:
-  - [ ] `custom_emoji_id`
-  - [ ] support documented modern entity types such as `custom_emoji`,
+- [x] Add or update shared message-related types:
+  - [x] `MessageId`
+  - [x] `InaccessibleMessage`
+  - [x] `MaybeInaccessibleMessage`
+  - [x] `ReplyParameters`
+  - [x] `TextQuote`
+  - [x] `ExternalReplyInfo`
+  - [x] `LinkPreviewOptions`
+  - [x] `MessageOriginUser`
+  - [x] `MessageOriginHiddenUser`
+  - [x] `MessageOriginChat`
+  - [x] `MessageOriginChannel`
+- [x] Expand `Message` with common modern fields:
+  - [x] `message_thread_id`
+  - [x] `direct_messages_topic`
+  - [x] `sender_chat`
+  - [x] `sender_boost_count`
+  - [x] `sender_business_bot`
+  - [x] `business_connection_id`
+  - [x] `forward_origin`
+  - [x] `is_topic_message`
+  - [x] `is_automatic_forward`
+  - [x] `reply_to_message`
+  - [x] `external_reply`
+  - [x] `quote`
+  - [x] `reply_to_story`
+  - [x] `reply_to_checklist_task_id`
+  - [x] `reply_to_poll_option_id`
+  - [x] `has_protected_content`
+  - [x] `is_from_offline`
+  - [x] `is_paid_post`
+  - [x] `paid_star_count`
+  - [x] `effect_id`
+  - [x] `show_caption_above_media`
+  - [x] `has_media_spoiler`
+  - [x] `reply_markup`
+- [x] Expand `MessageEntity` with modern fields:
+  - [x] `custom_emoji_id`
+  - [x] support documented modern entity types such as `custom_emoji`,
         `blockquote`, `expandable_blockquote`, and `date_time`.
 
 ## Phase 4: Common Media And Interaction Types

--- a/spec/message_type_upgrade_spec.cr
+++ b/spec/message_type_upgrade_spec.cr
@@ -1,0 +1,163 @@
+require "./spec_helper"
+
+describe TelegramBot::Message do
+  it "parses modern core message fields" do
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 42,
+        "message_thread_id": 7,
+        "direct_messages_topic": {"topic_id": 3},
+        "from": {"id": 1, "is_bot": false, "first_name": "Sender"},
+        "sender_chat": {"id": -100, "type": "supergroup", "title": "Group"},
+        "sender_boost_count": 2,
+        "sender_business_bot": {"id": 2, "is_bot": true, "first_name": "Business Bot"},
+        "date": 0,
+        "business_connection_id": "business-id",
+        "chat": {"id": 1, "type": "private"},
+        "forward_origin": {
+          "type": "user",
+          "date": 0,
+          "sender_user": {"id": 3, "is_bot": false, "first_name": "Original"}
+        },
+        "is_topic_message": true,
+        "is_automatic_forward": true,
+        "external_reply": {
+          "origin": {"type": "hidden_user", "date": 0, "sender_user_name": "Hidden"},
+          "message_id": 10,
+          "link_preview_options": {"url": "https://example.com"}
+        },
+        "quote": {
+          "text": "quoted",
+          "position": 0,
+          "entities": [{"type": "bold", "offset": 0, "length": 6}],
+          "is_manual": true
+        },
+        "reply_to_story": {
+          "chat": {"id": 1, "type": "private"},
+          "id": 99
+        },
+        "reply_to_checklist_task_id": 5,
+        "reply_to_poll_option_id": "option-id",
+        "has_protected_content": true,
+        "is_from_offline": true,
+        "is_paid_post": true,
+        "paid_star_count": 15,
+        "text": "hello",
+        "link_preview_options": {"is_disabled": false, "show_above_text": true},
+        "effect_id": "effect-id",
+        "show_caption_above_media": true,
+        "has_media_spoiler": true,
+        "reply_markup": {"inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]}
+      }
+      JSON
+
+    message.message_thread_id.should eq(7)
+    message.direct_messages_topic.try(&.["topic_id"].as_i).should eq(3)
+    message.sender_chat.try(&.title).should eq("Group")
+    message.sender_boost_count.should eq(2)
+    message.sender_business_bot.try(&.first_name).should eq("Business Bot")
+    message.business_connection_id.should eq("business-id")
+    message.forward_origin.try(&.type).should eq("user")
+    message.is_topic_message?.should be_true
+    message.is_automatic_forward?.should be_true
+    message.external_reply.try(&.origin.type).should eq("hidden_user")
+    message.external_reply.try(&.link_preview_options.try(&.url)).should eq("https://example.com")
+    message.quote.try(&.text).should eq("quoted")
+    message.quote.try(&.is_manual?).should be_true
+    message.reply_to_story.try(&.id).should eq(99)
+    message.reply_to_checklist_task_id.should eq(5)
+    message.reply_to_poll_option_id.should eq("option-id")
+    message.has_protected_content?.should be_true
+    message.is_from_offline?.should be_true
+    message.is_paid_post?.should be_true
+    message.paid_star_count.should eq(15)
+    message.link_preview_options.try(&.show_above_text?).should be_true
+    message.effect_id.should eq("effect-id")
+    message.show_caption_above_media?.should be_true
+    message.has_media_spoiler?.should be_true
+    message.reply_markup.try(&.inline_keyboard.first.first.text).should eq("Open")
+  end
+end
+
+describe TelegramBot::MessageEntity do
+  it "parses modern entity fields" do
+    custom_emoji = TelegramBot::MessageEntity.from_json(<<-JSON)
+      {
+        "type": "custom_emoji",
+        "offset": 0,
+        "length": 2,
+        "custom_emoji_id": "custom-emoji-id"
+      }
+      JSON
+    date_time = TelegramBot::MessageEntity.from_json(<<-JSON)
+      {
+        "type": "date_time",
+        "offset": 0,
+        "length": 5,
+        "unix_time": 1770000000,
+        "date_time_format": "date"
+      }
+      JSON
+
+    custom_emoji.custom_emoji_id.should eq("custom-emoji-id")
+    date_time.unix_time.should eq(1770000000)
+    date_time.date_time_format.should eq("date")
+  end
+end
+
+describe TelegramBot::ReplyParameters do
+  it "serializes reply and link preview options" do
+    reply_parameters = TelegramBot::ReplyParameters.new(
+      42,
+      chat_id: "@channel",
+      allow_sending_without_reply: true,
+      quote: "quoted",
+      quote_entities: [TelegramBot::MessageEntity.new("bold", 0, 6)],
+      quote_position: 0,
+      checklist_task_id: 1,
+      poll_option_id: "option-id"
+    )
+    link_preview_options = TelegramBot::LinkPreviewOptions.new(
+      is_disabled: false,
+      url: "https://example.com",
+      prefer_small_media: true,
+      show_above_text: true
+    )
+
+    JSON.parse(reply_parameters.to_json).should eq(JSON.parse(<<-JSON))
+      {
+        "message_id": 42,
+        "chat_id": "@channel",
+        "allow_sending_without_reply": true,
+        "quote": "quoted",
+        "quote_entities": [{"type": "bold", "offset": 0, "length": 6}],
+        "quote_position": 0,
+        "checklist_task_id": 1,
+        "poll_option_id": "option-id"
+      }
+      JSON
+    JSON.parse(link_preview_options.to_json).should eq(JSON.parse(<<-JSON))
+      {
+        "is_disabled": false,
+        "url": "https://example.com",
+        "prefer_small_media": true,
+        "show_above_text": true
+      }
+      JSON
+  end
+end
+
+describe TelegramBot::MessageOriginUser do
+  it "parses concrete message origin types" do
+    origin = TelegramBot::MessageOriginUser.from_json(<<-JSON)
+      {
+        "type": "user",
+        "date": 0,
+        "sender_user": {"id": 1, "is_bot": false, "first_name": "User"}
+      }
+      JSON
+
+    origin.type.should eq("user")
+    origin.sender_user.first_name.should eq("User")
+  end
+end

--- a/src/telegram_bot/types/external_reply_info.cr
+++ b/src/telegram_bot/types/external_reply_info.cr
@@ -1,0 +1,32 @@
+module TelegramBot
+  class ExternalReplyInfo
+    include JSON::Serializable
+
+    property origin : MessageOrigin
+    property chat : Chat?
+    property message_id : Int32?
+    property link_preview_options : LinkPreviewOptions?
+    property animation : Animation?
+    property audio : Audio?
+    property document : Document?
+    property live_photo : JSON::Any?
+    property paid_media : JSON::Any?
+    property photo : Array(PhotoSize)?
+    property sticker : Sticker?
+    property story : JSON::Any?
+    property video : Video?
+    property video_note : VideoNote?
+    property voice : Voice?
+    property? has_media_spoiler : Bool?
+    property checklist : JSON::Any?
+    property contact : Contact?
+    property dice : JSON::Any?
+    property game : Game?
+    property giveaway : JSON::Any?
+    property giveaway_winners : JSON::Any?
+    property invoice : Invoice?
+    property location : Location?
+    property poll : Poll?
+    property venue : Venue?
+  end
+end

--- a/src/telegram_bot/types/inaccessible_message.cr
+++ b/src/telegram_bot/types/inaccessible_message.cr
@@ -1,0 +1,11 @@
+module TelegramBot
+  class InaccessibleMessage
+    include JSON::Serializable
+
+    property chat : Chat
+    property message_id : Int32
+    property date : Int32
+  end
+
+  alias MaybeInaccessibleMessage = Message | InaccessibleMessage
+end

--- a/src/telegram_bot/types/link_preview_options.cr
+++ b/src/telegram_bot/types/link_preview_options.cr
@@ -1,0 +1,21 @@
+module TelegramBot
+  class LinkPreviewOptions
+    include JSON::Serializable
+
+    property? is_disabled : Bool?
+    property url : String?
+    property? prefer_small_media : Bool?
+    property? prefer_large_media : Bool?
+    property? show_above_text : Bool?
+
+    def initialize(
+      *,
+      @is_disabled = nil,
+      @url = nil,
+      @prefer_small_media = nil,
+      @prefer_large_media = nil,
+      @show_above_text = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -3,22 +3,42 @@ module TelegramBot
     include JSON::Serializable
 
     property message_id : Int32
+    property message_thread_id : Int32?
+    property direct_messages_topic : JSON::Any?
     property from : User?
+    property sender_chat : Chat?
+    property sender_boost_count : Int32?
+    property sender_business_bot : User?
     property date : Int32
+    property business_connection_id : String?
     property chat : Chat
+    property forward_origin : MessageOrigin?
     property forward_from : User?
     property forward_from_chat : Chat?
     property forward_from_message_id : Int32?
     property forward_signature : String?
     property forward_sender_name : String?
     property forward_date : Int32?
+    property? is_topic_message : Bool?
+    property? is_automatic_forward : Bool?
     property reply_to_message : Message?
+    property external_reply : ExternalReplyInfo?
+    property quote : TextQuote?
+    property reply_to_story : Story?
+    property reply_to_checklist_task_id : Int32?
+    property reply_to_poll_option_id : String?
     property via_bot : User?
     property edit_date : Int32?
+    property? has_protected_content : Bool?
+    property? is_from_offline : Bool?
+    property? is_paid_post : Bool?
     property media_group_id : String?
     property author_signature : String?
+    property paid_star_count : Int32?
     property text : String?
     property entities : Array(MessageEntity)?
+    property link_preview_options : LinkPreviewOptions?
+    property effect_id : String?
     property animation : Animation?
     property audio : Audio?
     property document : Document?
@@ -29,6 +49,8 @@ module TelegramBot
     property voice : Voice?
     property caption : String?
     property caption_entities : Array(MessageEntity)?
+    property? show_caption_above_media : Bool?
+    property? has_media_spoiler : Bool?
     property contact : Contact?
     property location : Location?
     property venue : Venue?
@@ -46,5 +68,6 @@ module TelegramBot
     property pinned_message : Message?
     property invoice : Invoice?
     property successful_payment : SuccessfulPayment?
+    property reply_markup : InlineKeyboardMarkup?
   end
 end

--- a/src/telegram_bot/types/message_entity.cr
+++ b/src/telegram_bot/types/message_entity.cr
@@ -8,6 +8,9 @@ module TelegramBot
     property url : String?
     property user : User?
     property language : String?
+    property custom_emoji_id : String?
+    property unix_time : Int32?
+    property date_time_format : String?
 
     def initialize(
       @type : String,
@@ -17,6 +20,9 @@ module TelegramBot
       @url = nil,
       @user = nil,
       @language : String? = nil,
+      @custom_emoji_id = nil,
+      @unix_time = nil,
+      @date_time_format = nil,
     )
     end
   end

--- a/src/telegram_bot/types/message_id.cr
+++ b/src/telegram_bot/types/message_id.cr
@@ -1,0 +1,7 @@
+module TelegramBot
+  class MessageId
+    include JSON::Serializable
+
+    property message_id : Int32
+  end
+end

--- a/src/telegram_bot/types/message_origin.cr
+++ b/src/telegram_bot/types/message_origin.cr
@@ -1,0 +1,27 @@
+module TelegramBot
+  class MessageOrigin
+    include JSON::Serializable
+
+    property type : String
+    property date : Int32
+  end
+
+  class MessageOriginUser < MessageOrigin
+    property sender_user : User
+  end
+
+  class MessageOriginHiddenUser < MessageOrigin
+    property sender_user_name : String
+  end
+
+  class MessageOriginChat < MessageOrigin
+    property sender_chat : Chat
+    property author_signature : String?
+  end
+
+  class MessageOriginChannel < MessageOrigin
+    property chat : Chat
+    property message_id : Int32
+    property author_signature : String?
+  end
+end

--- a/src/telegram_bot/types/reply_parameters.cr
+++ b/src/telegram_bot/types/reply_parameters.cr
@@ -3,7 +3,7 @@ module TelegramBot
     include JSON::Serializable
 
     property message_id : Int32
-    property chat_id : Int64 | String | Nil
+    property chat_id : Int64 | String?
     property? allow_sending_without_reply : Bool?
     property quote : String?
     property quote_parse_mode : String?

--- a/src/telegram_bot/types/reply_parameters.cr
+++ b/src/telegram_bot/types/reply_parameters.cr
@@ -1,0 +1,29 @@
+module TelegramBot
+  class ReplyParameters
+    include JSON::Serializable
+
+    property message_id : Int32
+    property chat_id : Int64 | String | Nil
+    property? allow_sending_without_reply : Bool?
+    property quote : String?
+    property quote_parse_mode : String?
+    property quote_entities : Array(MessageEntity)?
+    property quote_position : Int32?
+    property checklist_task_id : Int32?
+    property poll_option_id : String?
+
+    def initialize(
+      @message_id : Int32,
+      *,
+      @chat_id = nil,
+      @allow_sending_without_reply = nil,
+      @quote = nil,
+      @quote_parse_mode = nil,
+      @quote_entities = nil,
+      @quote_position = nil,
+      @checklist_task_id = nil,
+      @poll_option_id = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/story.cr
+++ b/src/telegram_bot/types/story.cr
@@ -1,0 +1,8 @@
+module TelegramBot
+  class Story
+    include JSON::Serializable
+
+    property chat : Chat
+    property id : Int32
+  end
+end

--- a/src/telegram_bot/types/text_quote.cr
+++ b/src/telegram_bot/types/text_quote.cr
@@ -1,0 +1,10 @@
+module TelegramBot
+  class TextQuote
+    include JSON::Serializable
+
+    property text : String
+    property entities : Array(MessageEntity)?
+    property position : Int32
+    property? is_manual : Bool?
+  end
+end


### PR DESCRIPTION
## Summary

- Add shared message-related types:
  - `MessageId`
  - `InaccessibleMessage`
  - `MaybeInaccessibleMessage`
  - `ReplyParameters`
  - `TextQuote`
  - `ExternalReplyInfo`
  - `LinkPreviewOptions`
  - `MessageOrigin*`
  - `Story`
- Expand `Message` with modern core fields for topics, business messages, forwarding origins, replies, quotes, protection flags, paid post metadata, link previews, media caption behavior, and inline reply markup
- Expand `MessageEntity` with `custom_emoji_id`, `unix_time`, and `date_time_format`
- Add focused parse/serialization coverage for the new message types