### PR TITLE
Add common Telegram interaction types

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -102,36 +102,36 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 4: Common Media And Interaction Types
 
-- [ ] Add `Animation` sending support where missing from methods.
-- [ ] Add `Dice`.
-- [ ] Add poll types:
-  - [ ] `Poll`
-  - [ ] `PollOption`
-  - [ ] `InputPollOption`
-  - [ ] `InputPollMedia`
-  - [ ] `InputPollOptionMedia`
-  - [ ] `PollAnswer`
-  - [ ] `PollOptionAdded`
-  - [ ] `PollOptionDeleted`
-- [ ] Add reaction types:
-  - [ ] `ReactionTypeEmoji`
-  - [ ] `ReactionTypeCustomEmoji`
-  - [ ] `ReactionTypePaid`
-  - [ ] `MessageReactionUpdated`
-  - [ ] `MessageReactionCountUpdated`
-  - [ ] `ReactionCount`
-- [ ] Add forum topic service types:
-  - [ ] `ForumTopic`
-  - [ ] `ForumTopicCreated`
-  - [ ] `ForumTopicEdited`
-  - [ ] `ForumTopicClosed`
-  - [ ] `ForumTopicReopened`
-  - [ ] `GeneralForumTopicHidden`
-  - [ ] `GeneralForumTopicUnhidden`
+- [x] Add `Animation` sending support where missing from methods.
+- [x] Add `Dice`.
+- [x] Add poll types:
+  - [x] `Poll`
+  - [x] `PollOption`
+  - [x] `InputPollOption`
+  - [x] `InputPollMedia`
+  - [x] `InputPollOptionMedia`
+  - [x] `PollAnswer`
+  - [x] `PollOptionAdded`
+  - [x] `PollOptionDeleted`
+- [x] Add reaction types:
+  - [x] `ReactionTypeEmoji`
+  - [x] `ReactionTypeCustomEmoji`
+  - [x] `ReactionTypePaid`
+  - [x] `MessageReactionUpdated`
+  - [x] `MessageReactionCountUpdated`
+  - [x] `ReactionCount`
+- [x] Add forum topic service types:
+  - [x] `ForumTopic`
+  - [x] `ForumTopicCreated`
+  - [x] `ForumTopicEdited`
+  - [x] `ForumTopicClosed`
+  - [x] `ForumTopicReopened`
+  - [x] `GeneralForumTopicHidden`
+  - [x] `GeneralForumTopicUnhidden`
 
 ## Phase 5: Common Sending Methods
 
-- [ ] Add `send_animation`.
+- [x] Add `send_animation`.
 - [ ] Add `send_poll`.
 - [ ] Add `send_dice`.
 - [ ] Add `copy_message`.

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -1,0 +1,140 @@
+require "./spec_helper"
+
+describe TelegramBot::Message do
+  it "parses dice, poll, and forum service fields" do
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "dice": {"emoji": "🎲", "value": 6},
+        "poll": {
+          "id": "poll-id",
+          "question": "Question?",
+          "options": [
+            {
+              "persistent_id": "option-id",
+              "text": "Option",
+              "voter_count": 1,
+              "media": {"photo": [{"file_id": "file-id", "width": 1, "height": 1}]}
+            }
+          ],
+          "total_voter_count": 1,
+          "is_closed": false,
+          "is_anonymous": false,
+          "type": "regular",
+          "allows_multiple_answers": false,
+          "allows_revoting": true,
+          "media": {"photo": [{"file_id": "file-id", "width": 1, "height": 1}]}
+        },
+        "forum_topic_created": {
+          "name": "Topic",
+          "icon_color": 16711680,
+          "icon_custom_emoji_id": "emoji-id",
+          "is_name_implicit": true
+        },
+        "forum_topic_edited": {
+          "name": "New Topic",
+          "icon_custom_emoji_id": ""
+        },
+        "forum_topic_closed": {},
+        "forum_topic_reopened": {},
+        "general_forum_topic_hidden": {},
+        "general_forum_topic_unhidden": {},
+        "poll_option_added": {
+          "option_persistent_id": "added-option-id",
+          "option_text": "Added"
+        },
+        "poll_option_deleted": {
+          "option_persistent_id": "deleted-option-id",
+          "option_text": "Deleted"
+        }
+      }
+      JSON
+
+    message.dice.try(&.value).should eq(6)
+    message.poll.try(&.id).should eq("poll-id")
+    message.poll.try(&.options.try(&.first.persistent_id)).should eq("option-id")
+    message.poll.try(&.options.try(&.first.media.try(&.photo.try(&.first.file_id)))).should eq("file-id")
+    message.poll.try(&.allows_revoting?).should be_true
+    message.poll.try(&.media.try(&.photo.try(&.first.file_id))).should eq("file-id")
+    message.forum_topic_created.try(&.name).should eq("Topic")
+    message.forum_topic_created.try(&.is_name_implicit?).should be_true
+    message.forum_topic_edited.try(&.name).should eq("New Topic")
+    message.forum_topic_closed.should be_a(TelegramBot::ForumTopicClosed)
+    message.forum_topic_reopened.should be_a(TelegramBot::ForumTopicReopened)
+    message.general_forum_topic_hidden.should be_a(TelegramBot::GeneralForumTopicHidden)
+    message.general_forum_topic_unhidden.should be_a(TelegramBot::GeneralForumTopicUnhidden)
+    message.poll_option_added.try(&.option_persistent_id).should eq("added-option-id")
+    message.poll_option_deleted.try(&.option_persistent_id).should eq("deleted-option-id")
+  end
+end
+
+describe TelegramBot::InputPollOption do
+  it "serializes poll option input" do
+    option = TelegramBot::InputPollOption.new(
+      "Option",
+      text_entities: [TelegramBot::MessageEntity.new("custom_emoji", 0, 2, custom_emoji_id: "emoji-id")]
+    )
+
+    JSON.parse(option.to_json).should eq(JSON.parse(<<-JSON))
+      {
+        "text": "Option",
+        "text_entities": [
+          {
+            "type": "custom_emoji",
+            "offset": 0,
+            "length": 2,
+            "custom_emoji_id": "emoji-id"
+          }
+        ]
+      }
+      JSON
+  end
+end
+
+describe TelegramBot::ReactionType do
+  it "parses reaction updates and serializes reaction types" do
+    update = TelegramBot::MessageReactionUpdated.from_json(<<-JSON)
+      {
+        "chat": {"id": 1, "type": "private"},
+        "message_id": 1,
+        "date": 0,
+        "old_reaction": [{"type": "emoji", "emoji": "👍"}],
+        "new_reaction": [{"type": "custom_emoji", "custom_emoji_id": "emoji-id"}]
+      }
+      JSON
+    count = TelegramBot::ReactionCount.from_json(<<-JSON)
+      {
+        "type": {"type": "paid"},
+        "total_count": 3
+      }
+      JSON
+
+    update.old_reaction.try(&.first.emoji).should eq("👍")
+    update.new_reaction.try(&.first.custom_emoji_id).should eq("emoji-id")
+    count.type.try(&.type).should eq("paid")
+    count.total_count.should eq(3)
+
+    JSON.parse(TelegramBot::ReactionTypeEmoji.new("👍").to_json).should eq(JSON.parse(%({"type":"emoji","emoji":"👍"})))
+    JSON.parse(TelegramBot::ReactionTypeCustomEmoji.new("emoji-id").to_json).should eq(JSON.parse(%({"type":"custom_emoji","custom_emoji_id":"emoji-id"})))
+    JSON.parse(TelegramBot::ReactionTypePaid.new.to_json).should eq(JSON.parse(%({"type":"paid"})))
+  end
+end
+
+describe TelegramBot::ForumTopic do
+  it "parses forum topics" do
+    topic = TelegramBot::ForumTopic.from_json(<<-JSON)
+      {
+        "message_thread_id": 42,
+        "name": "Topic",
+        "icon_color": 16711680,
+        "icon_custom_emoji_id": "emoji-id"
+      }
+      JSON
+
+    topic.message_thread_id.should eq(42)
+    topic.name.should eq("Topic")
+    topic.icon_custom_emoji_id.should eq("emoji-id")
+  end
+end

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -16,7 +16,7 @@ describe TelegramBot::Message do
               "persistent_id": "option-id",
               "text": "Option",
               "voter_count": 1,
-              "media": {"photo": [{"file_id": "file-id", "width": 1, "height": 1}]}
+              "media": {"photo": [{"file_id": "file-id", "file_unique_id": "file-unique-id", "width": 1, "height": 1}]}
             }
           ],
           "total_voter_count": 1,
@@ -25,7 +25,7 @@ describe TelegramBot::Message do
           "type": "regular",
           "allows_multiple_answers": false,
           "allows_revoting": true,
-          "media": {"photo": [{"file_id": "file-id", "width": 1, "height": 1}]}
+          "media": {"photo": [{"file_id": "file-id", "file_unique_id": "file-unique-id", "width": 1, "height": 1}]}
         },
         "forum_topic_created": {
           "name": "Topic",

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -136,6 +136,18 @@ describe TelegramBot::Bot do
     bot.last_params["length"].should eq("240")
   end
 
+  it "builds sendAnimation" do
+    bot = RequestBuildingBot.new
+    bot.send_animation(123, "animation-id", duration: 10, width: 320, height: 240, caption: "caption")
+
+    bot.last_method.should eq("sendAnimation")
+    bot.last_params["animation"].should eq("animation-id")
+    bot.last_params["duration"].should eq("10")
+    bot.last_params["width"].should eq("320")
+    bot.last_params["height"].should eq("240")
+    bot.last_params["caption"].should eq("caption")
+  end
+
   it "builds sendInvoice with title" do
     bot = RequestBuildingBot.new
     bot.send_invoice(

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -513,6 +513,19 @@ module TelegramBot
       Message.from_json res.to_json if res
     end
 
+    def send_animation(chat_id : Int | String,
+                       animation : ::File | String,
+                       duration : Int32? = nil,
+                       width : Int32? = nil,
+                       height : Int32? = nil,
+                       caption : String? = nil,
+                       disable_notification : Bool? = nil,
+                       reply_to_message_id : Int32? = nil,
+                       reply_markup : ReplyMarkup = nil) : Message?
+      res = def_request "sendAnimation", chat_id, animation, duration, width, height, caption, disable_notification, reply_to_message_id, reply_markup
+      Message.from_json res.to_json if res
+    end
+
     def send_voice(chat_id : Int | String,
                    voice : ::File | String,
                    duration : Int32? = nil,

--- a/src/telegram_bot/types/dice.cr
+++ b/src/telegram_bot/types/dice.cr
@@ -1,0 +1,8 @@
+module TelegramBot
+  class Dice
+    include JSON::Serializable
+
+    property emoji : String
+    property value : Int32
+  end
+end

--- a/src/telegram_bot/types/external_reply_info.cr
+++ b/src/telegram_bot/types/external_reply_info.cr
@@ -20,7 +20,7 @@ module TelegramBot
     property? has_media_spoiler : Bool?
     property checklist : JSON::Any?
     property contact : Contact?
-    property dice : JSON::Any?
+    property dice : Dice?
     property game : Game?
     property giveaway : JSON::Any?
     property giveaway_winners : JSON::Any?

--- a/src/telegram_bot/types/forum_topic.cr
+++ b/src/telegram_bot/types/forum_topic.cr
@@ -1,0 +1,42 @@
+module TelegramBot
+  class ForumTopic
+    include JSON::Serializable
+
+    property message_thread_id : Int32
+    property name : String
+    property icon_color : Int32
+    property icon_custom_emoji_id : String?
+  end
+
+  class ForumTopicCreated
+    include JSON::Serializable
+
+    property name : String
+    property icon_color : Int32
+    property icon_custom_emoji_id : String?
+    property? is_name_implicit : Bool?
+  end
+
+  class ForumTopicEdited
+    include JSON::Serializable
+
+    property name : String?
+    property icon_custom_emoji_id : String?
+  end
+
+  class ForumTopicClosed
+    include JSON::Serializable
+  end
+
+  class ForumTopicReopened
+    include JSON::Serializable
+  end
+
+  class GeneralForumTopicHidden
+    include JSON::Serializable
+  end
+
+  class GeneralForumTopicUnhidden
+    include JSON::Serializable
+  end
+end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -52,6 +52,9 @@ module TelegramBot
     property? show_caption_above_media : Bool?
     property? has_media_spoiler : Bool?
     property contact : Contact?
+    property dice : Dice?
+    property game : Game?
+    property poll : Poll?
     property location : Location?
     property venue : Venue?
     property new_chat_members : Array(User)?
@@ -60,9 +63,16 @@ module TelegramBot
     property new_chat_photo : Array(PhotoSize)?
     property? delete_chat_photo : Bool?
     property? group_chat_created : Bool?
-    property? group_chat_created : Bool?
     property? supergroup_chat_created : Bool?
     property? channel_chat_created : Bool?
+    property forum_topic_created : ForumTopicCreated?
+    property forum_topic_edited : ForumTopicEdited?
+    property forum_topic_closed : ForumTopicClosed?
+    property forum_topic_reopened : ForumTopicReopened?
+    property general_forum_topic_hidden : GeneralForumTopicHidden?
+    property general_forum_topic_unhidden : GeneralForumTopicUnhidden?
+    property poll_option_added : PollOptionAdded?
+    property poll_option_deleted : PollOptionDeleted?
     property migrate_to_chat_id : Int32?
     property migrate_from_chat_id : Int32?
     property pinned_message : Message?

--- a/src/telegram_bot/types/message_reaction_updated.cr
+++ b/src/telegram_bot/types/message_reaction_updated.cr
@@ -7,14 +7,14 @@ module TelegramBot
     property user : User?
     property actor_chat : Chat?
     property date : Int32?
-    property old_reaction : Array(JSON::Any)?
-    property new_reaction : Array(JSON::Any)?
+    property old_reaction : Array(ReactionType)?
+    property new_reaction : Array(ReactionType)?
   end
 
   class ReactionCount
     include JSON::Serializable
 
-    property type : JSON::Any?
+    property type : ReactionType?
     property total_count : Int32?
   end
 

--- a/src/telegram_bot/types/poll.cr
+++ b/src/telegram_bot/types/poll.cr
@@ -1,4 +1,21 @@
 module TelegramBot
+  class PollMedia
+    include JSON::Serializable
+
+    property animation : Animation?
+    property audio : Audio?
+    property document : Document?
+    property live_photo : JSON::Any?
+    property location : Location?
+    property photo : Array(PhotoSize)?
+    property sticker : Sticker?
+    property venue : Venue?
+    property video : Video?
+  end
+
+  alias InputPollMedia = InputMedia
+  alias InputPollOptionMedia = InputMedia
+
   class PollOption
     include JSON::Serializable
 
@@ -9,7 +26,25 @@ module TelegramBot
     property added_by_user : User?
     property added_by_chat : Chat?
     property addition_date : Int32?
-    property media : JSON::Any?
+    property media : PollMedia?
+  end
+
+  class InputPollOption
+    include JSON::Serializable
+
+    property text : String
+    property text_parse_mode : String?
+    property text_entities : Array(MessageEntity)?
+    property media : InputPollOptionMedia?
+
+    def initialize(
+      @text : String,
+      *,
+      @text_parse_mode = nil,
+      @text_entities = nil,
+      @media = nil,
+    )
+    end
   end
 
   class Poll
@@ -32,9 +67,27 @@ module TelegramBot
     property? allows_revoting : Bool?
     property description : String?
     property description_entities : Array(MessageEntity)?
-    property media : JSON::Any?
-    property explanation_media : JSON::Any?
+    property media : PollMedia?
+    property explanation_media : PollMedia?
     property? members_only : Bool?
     property country_codes : Array(String)?
+  end
+
+  class PollOptionAdded
+    include JSON::Serializable
+
+    property poll_message : JSON::Any?
+    property option_persistent_id : String
+    property option_text : String
+    property option_text_entities : Array(MessageEntity)?
+  end
+
+  class PollOptionDeleted
+    include JSON::Serializable
+
+    property poll_message : JSON::Any?
+    property option_persistent_id : String
+    property option_text : String
+    property option_text_entities : Array(MessageEntity)?
   end
 end

--- a/src/telegram_bot/types/reaction_type.cr
+++ b/src/telegram_bot/types/reaction_type.cr
@@ -1,0 +1,31 @@
+module TelegramBot
+  class ReactionType
+    include JSON::Serializable
+
+    property type : String
+    property emoji : String?
+    property custom_emoji_id : String?
+  end
+
+  class ReactionTypeEmoji < ReactionType
+    def initialize(@emoji : String)
+      @type = "emoji"
+      @custom_emoji_id = nil
+    end
+  end
+
+  class ReactionTypeCustomEmoji < ReactionType
+    def initialize(@custom_emoji_id : String)
+      @type = "custom_emoji"
+      @emoji = nil
+    end
+  end
+
+  class ReactionTypePaid < ReactionType
+    def initialize
+      @type = "paid"
+      @emoji = nil
+      @custom_emoji_id = nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add common interaction/media DTOs:
  - `Dice`
  - `PollMedia`
  - `InputPollOption`
  - `InputPollMedia`
  - `InputPollOptionMedia`
  - `PollOptionAdded`
  - `PollOptionDeleted`
  - `ReactionType*`
  - `ForumTopic*`
- Tighten poll and reaction update models to use typed media/reaction DTOs
- Expand `Message` with dice, game, poll, forum topic service, and poll option service fields
- Add `send_animation` wrapper
- Add focused specs for common interaction type parsing and request building