### PR TITLE
Add keyboard and Web App support

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -231,42 +231,42 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 8: Keyboard, Inline, And Web App Support
 
-- [ ] Expand `InlineKeyboardButton` with:
-  - [ ] `login_url`
-  - [ ] `web_app`
-  - [ ] `switch_inline_query_current_chat`
-  - [ ] `switch_inline_query_chosen_chat`
-  - [ ] `copy_text`
-  - [ ] `callback_game`
-  - [ ] `pay`
-  - [ ] `icon_custom_emoji_id`
-  - [ ] `style`
-- [ ] Add keyboard/web app types:
-  - [ ] `LoginUrl`
-  - [ ] `WebAppInfo`
-  - [ ] `WebAppData`
-  - [ ] `SwitchInlineQueryChosenChat`
-  - [ ] `CopyTextButton`
-- [ ] Expand `KeyboardButton` with:
-  - [ ] `request_users`
-  - [ ] `request_chat`
-  - [ ] `request_contact`
-  - [ ] `request_location`
-  - [ ] `request_poll`
-  - [ ] `web_app`
-  - [ ] `request_managed_bot`
-  - [ ] `icon_custom_emoji_id`
-  - [ ] `style`
-- [ ] Add `KeyboardButtonRequestUsers`.
-- [ ] Add `KeyboardButtonRequestChat`.
-- [ ] Add `KeyboardButtonPollType`.
-- [ ] Add `KeyboardButtonRequestManagedBot`.
-- [ ] Add `answer_web_app_query`.
-- [ ] Add `SentWebAppMessage`.
-- [ ] Add `save_prepared_inline_message`.
-- [ ] Add `PreparedInlineMessage`.
-- [ ] Add `save_prepared_keyboard_button`.
-- [ ] Add `PreparedKeyboardButton`.
+- [x] Expand `InlineKeyboardButton` with:
+  - [x] `login_url`
+  - [x] `web_app`
+  - [x] `switch_inline_query_current_chat`
+  - [x] `switch_inline_query_chosen_chat`
+  - [x] `copy_text`
+  - [x] `callback_game`
+  - [x] `pay`
+  - [x] `icon_custom_emoji_id`
+  - [x] `style`
+- [x] Add keyboard/web app types:
+  - [x] `LoginUrl`
+  - [x] `WebAppInfo`
+  - [x] `WebAppData`
+  - [x] `SwitchInlineQueryChosenChat`
+  - [x] `CopyTextButton`
+- [x] Expand `KeyboardButton` with:
+  - [x] `request_users`
+  - [x] `request_chat`
+  - [x] `request_contact`
+  - [x] `request_location`
+  - [x] `request_poll`
+  - [x] `web_app`
+  - [x] `request_managed_bot`
+  - [x] `icon_custom_emoji_id`
+  - [x] `style`
+- [x] Add `KeyboardButtonRequestUsers`.
+- [x] Add `KeyboardButtonRequestChat`.
+- [x] Add `KeyboardButtonPollType`.
+- [x] Add `KeyboardButtonRequestManagedBot`.
+- [x] Add `answer_web_app_query`.
+- [x] Add `SentWebAppMessage`.
+- [x] Add `save_prepared_inline_message`.
+- [x] Add `PreparedInlineMessage`.
+- [x] Add `save_prepared_keyboard_button`.
+- [x] Add `PreparedKeyboardButton`.
 
 ## Phase 9: Payments, Stars, Gifts, Paid Media
 

--- a/spec/message_type_upgrade_spec.cr
+++ b/spec/message_type_upgrade_spec.cr
@@ -47,7 +47,7 @@ describe TelegramBot::Message do
         "effect_id": "effect-id",
         "show_caption_above_media": true,
         "has_media_spoiler": true,
-        "web_app_data": {"data": "{"action":"done"}", "button_text": "Finish"},
+        "web_app_data": {"data": "action=done", "button_text": "Finish"},
         "reply_markup": {"inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]}
       }
       JSON

--- a/spec/message_type_upgrade_spec.cr
+++ b/spec/message_type_upgrade_spec.cr
@@ -47,6 +47,7 @@ describe TelegramBot::Message do
         "effect_id": "effect-id",
         "show_caption_above_media": true,
         "has_media_spoiler": true,
+        "web_app_data": {"data": "{"action":"done"}", "button_text": "Finish"},
         "reply_markup": {"inline_keyboard": [[{"text": "Open", "url": "https://example.com"}]]}
       }
       JSON
@@ -75,6 +76,7 @@ describe TelegramBot::Message do
     message.effect_id.should eq("effect-id")
     message.show_caption_above_media?.should be_true
     message.has_media_spoiler?.should be_true
+    message.web_app_data.try(&.button_text).should eq("Finish")
     message.reply_markup.try(&.inline_keyboard.first.first.text).should eq("Open")
   end
 end

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -23,6 +23,12 @@ class RequestBuildingBot < TelegramBot::Bot
     case method
     when "answerInlineQuery", "answerShippingQuery", "answerPreCheckoutQuery", "pinChatMessage", "unpinChatMessage", "sendMessageDraft", "setMyCommands"
       JSON.parse("true")
+    when "answerWebAppQuery"
+      JSON.parse(%({"inline_message_id":"inline-id"}))
+    when "savePreparedInlineMessage"
+      JSON.parse(%({"id":"prepared-inline-id","expiration_date":1800000000}))
+    when "savePreparedKeyboardButton"
+      JSON.parse(%({"id":"prepared-keyboard-id"}))
     when "copyMessage"
       JSON.parse(%({"message_id":100}))
     when "copyMessages", "forwardMessages"
@@ -351,6 +357,134 @@ describe TelegramBot::Bot do
     else
       fail "expected results param"
     end
+  end
+
+  it "serializes modern inline keyboard button fields" do
+    bot = RequestBuildingBot.new
+    markup = TelegramBot::InlineKeyboardMarkup.new([
+      [
+        TelegramBot::InlineKeyboardButton.new(
+          "Open",
+          icon_custom_emoji_id: "emoji-id",
+          style: "primary",
+          web_app: TelegramBot::WebAppInfo.new("https://example.com/app"),
+          login_url: TelegramBot::LoginUrl.new("https://example.com/login", request_write_access: true),
+          switch_inline_query_current_chat: "search",
+          switch_inline_query_chosen_chat: TelegramBot::SwitchInlineQueryChosenChat.new(
+            query: "chosen",
+            allow_user_chats: true
+          ),
+          copy_text: TelegramBot::CopyTextButton.new("copy me"),
+          pay: true
+        ),
+      ],
+    ])
+    params = bot.serialize_for_spec({"reply_markup" => markup})
+
+    JSON.parse(params["reply_markup"].as(String)).should eq(JSON.parse(<<-JSON))
+      {
+        "inline_keyboard": [[{
+          "text": "Open",
+          "icon_custom_emoji_id": "emoji-id",
+          "style": "primary",
+          "web_app": {"url": "https://example.com/app"},
+          "login_url": {"url": "https://example.com/login", "request_write_access": true},
+          "switch_inline_query_current_chat": "search",
+          "switch_inline_query_chosen_chat": {"query": "chosen", "allow_user_chats": true},
+          "copy_text": {"text": "copy me"},
+          "pay": true
+        }]]
+      }
+      JSON
+  end
+
+  it "serializes modern reply keyboard button fields" do
+    bot = RequestBuildingBot.new
+    markup = TelegramBot::ReplyKeyboardMarkup.new([
+      [
+        TelegramBot::KeyboardButton.new(
+          "Share",
+          icon_custom_emoji_id: "emoji-id",
+          style: "success",
+          request_users: TelegramBot::KeyboardButtonRequestUsers.new(
+            1,
+            user_is_bot: false,
+            max_quantity: 2,
+            request_username: true
+          ),
+          request_chat: TelegramBot::KeyboardButtonRequestChat.new(
+            2,
+            false,
+            bot_administrator_rights: TelegramBot::ChatAdministratorRights.new(can_invite_users: true),
+            request_title: true
+          ),
+          request_managed_bot: TelegramBot::KeyboardButtonRequestManagedBot.new(
+            3,
+            suggested_username: "managed_bot"
+          ),
+          request_poll: TelegramBot::KeyboardButtonPollType.new("quiz"),
+          web_app: TelegramBot::WebAppInfo.new("https://example.com/reply-app")
+        ),
+      ],
+    ])
+    params = bot.serialize_for_spec({"reply_markup" => markup})
+
+    JSON.parse(params["reply_markup"].as(String)).should eq(JSON.parse(<<-JSON))
+      {
+        "keyboard": [[{
+          "text": "Share",
+          "icon_custom_emoji_id": "emoji-id",
+          "style": "success",
+          "request_users": {
+            "request_id": 1,
+            "user_is_bot": false,
+            "max_quantity": 2,
+            "request_username": true
+          },
+          "request_chat": {
+            "request_id": 2,
+            "chat_is_channel": false,
+            "bot_administrator_rights": {"can_invite_users": true},
+            "request_title": true
+          },
+          "request_managed_bot": {
+            "request_id": 3,
+            "suggested_username": "managed_bot"
+          },
+          "request_poll": {"type": "quiz"},
+          "web_app": {"url": "https://example.com/reply-app"}
+        }]]
+      }
+      JSON
+  end
+
+  it "builds Web App and prepared message methods" do
+    bot = RequestBuildingBot.new
+    content = TelegramBot::InputTextMessageContent.new("Web App result")
+    result = TelegramBot::InlineQueryResultArticle.new("article/1", "Article", content)
+
+    sent = bot.answer_web_app_query("web-app-query-id", result)
+
+    sent.inline_message_id.should eq("inline-id")
+    bot.last_method.should eq("answerWebAppQuery")
+    bot.last_params["web_app_query_id"].should eq("web-app-query-id")
+    bot.param("result").should contain("InlineQueryResultArticle")
+
+    prepared_inline = bot.save_prepared_inline_message(1, result, allow_user_chats: true)
+
+    prepared_inline.id.should eq("prepared-inline-id")
+    prepared_inline.expiration_date.should eq(1_800_000_000)
+    bot.last_method.should eq("savePreparedInlineMessage")
+    bot.last_params["allow_user_chats"].should eq("true")
+
+    prepared_button = bot.save_prepared_keyboard_button(
+      1,
+      TelegramBot::KeyboardButton.new("Share user", request_users: TelegramBot::KeyboardButtonRequestUsers.new(1))
+    )
+
+    prepared_button.id.should eq("prepared-keyboard-id")
+    bot.last_method.should eq("savePreparedKeyboardButton")
+    bot.param("button").should contain("KeyboardButton")
   end
 
   it "builds multipart bodies with serialized non-file params" do

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -1088,6 +1088,28 @@ module TelegramBot
       res.as_bool if res
     end
 
+    def answer_web_app_query(web_app_query_id : String,
+                             result : InlineQueryResult) : SentWebAppMessage
+      res = def_request "answerWebAppQuery", web_app_query_id, result
+      SentWebAppMessage.from_json(res.to_json)
+    end
+
+    def save_prepared_inline_message(user_id : Int,
+                                     result : InlineQueryResult,
+                                     allow_user_chats : Bool? = nil,
+                                     allow_bot_chats : Bool? = nil,
+                                     allow_group_chats : Bool? = nil,
+                                     allow_channel_chats : Bool? = nil) : PreparedInlineMessage
+      res = def_request "savePreparedInlineMessage", user_id, result, allow_user_chats, allow_bot_chats, allow_group_chats, allow_channel_chats
+      PreparedInlineMessage.from_json(res.to_json)
+    end
+
+    def save_prepared_keyboard_button(user_id : Int,
+                                      button : KeyboardButton) : PreparedKeyboardButton
+      res = def_request "savePreparedKeyboardButton", user_id, button
+      PreparedKeyboardButton.from_json(res.to_json)
+    end
+
     def get_file(file_id : String) : File
       res = def_force_request "getFile", file_id
       File.from_json(res.to_json)

--- a/src/telegram_bot/types/callback_game.cr
+++ b/src/telegram_bot/types/callback_game.cr
@@ -1,5 +1,7 @@
 module TelegramBot
   class CallbackGame
+    include JSON::Serializable
+
     # A placeholder, currently holds no information. Use BotFather to set up your game.
   end
 end

--- a/src/telegram_bot/types/chat_administrator_rights.cr
+++ b/src/telegram_bot/types/chat_administrator_rights.cr
@@ -1,0 +1,45 @@
+module TelegramBot
+  class ChatAdministratorRights
+    include JSON::Serializable
+
+    property? is_anonymous : Bool?
+    property? can_manage_chat : Bool?
+    property? can_delete_messages : Bool?
+    property? can_manage_video_chats : Bool?
+    property? can_restrict_members : Bool?
+    property? can_promote_members : Bool?
+    property? can_change_info : Bool?
+    property? can_invite_users : Bool?
+    property? can_post_stories : Bool?
+    property? can_edit_stories : Bool?
+    property? can_delete_stories : Bool?
+    property? can_post_messages : Bool?
+    property? can_edit_messages : Bool?
+    property? can_pin_messages : Bool?
+    property? can_manage_topics : Bool?
+    property? can_manage_direct_messages : Bool?
+    property? can_manage_tags : Bool?
+
+    def initialize(
+      *,
+      @is_anonymous = nil,
+      @can_manage_chat = nil,
+      @can_delete_messages = nil,
+      @can_manage_video_chats = nil,
+      @can_restrict_members = nil,
+      @can_promote_members = nil,
+      @can_change_info = nil,
+      @can_invite_users = nil,
+      @can_post_stories = nil,
+      @can_edit_stories = nil,
+      @can_delete_stories = nil,
+      @can_post_messages = nil,
+      @can_edit_messages = nil,
+      @can_pin_messages = nil,
+      @can_manage_topics = nil,
+      @can_manage_direct_messages = nil,
+      @can_manage_tags = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/copy_text_button.cr
+++ b/src/telegram_bot/types/copy_text_button.cr
@@ -1,0 +1,10 @@
+module TelegramBot
+  class CopyTextButton
+    include JSON::Serializable
+
+    property text : String
+
+    def initialize(@text : String)
+    end
+  end
+end

--- a/src/telegram_bot/types/inline/inline_keyboard_button.cr
+++ b/src/telegram_bot/types/inline/inline_keyboard_button.cr
@@ -3,16 +3,34 @@ module TelegramBot
     include JSON::Serializable
 
     property text : String
+    property icon_custom_emoji_id : String?
+    property style : String?
     property url : String?
     property callback_data : String?
+    property web_app : WebAppInfo?
+    property login_url : LoginUrl?
     property switch_inline_query : String?
+    property switch_inline_query_current_chat : String?
+    property switch_inline_query_chosen_chat : SwitchInlineQueryChosenChat?
+    property copy_text : CopyTextButton?
+    property callback_game : CallbackGame?
+    property? pay : Bool?
 
     def initialize(
       @text : String,
       *,
+      @icon_custom_emoji_id : String? = nil,
+      @style : String? = nil,
       @url : String? = nil,
       @callback_data : String? = nil,
+      @web_app : WebAppInfo? = nil,
+      @login_url : LoginUrl? = nil,
       @switch_inline_query : String? = nil,
+      @switch_inline_query_current_chat : String? = nil,
+      @switch_inline_query_chosen_chat : SwitchInlineQueryChosenChat? = nil,
+      @copy_text : CopyTextButton? = nil,
+      @callback_game : CallbackGame? = nil,
+      @pay = nil,
     )
     end
   end

--- a/src/telegram_bot/types/keyboard_button_poll_type.cr
+++ b/src/telegram_bot/types/keyboard_button_poll_type.cr
@@ -1,0 +1,10 @@
+module TelegramBot
+  class KeyboardButtonPollType
+    include JSON::Serializable
+
+    property type : String?
+
+    def initialize(@type : String? = nil)
+    end
+  end
+end

--- a/src/telegram_bot/types/keyboard_button_request_chat.cr
+++ b/src/telegram_bot/types/keyboard_button_request_chat.cr
@@ -1,0 +1,33 @@
+module TelegramBot
+  class KeyboardButtonRequestChat
+    include JSON::Serializable
+
+    property request_id : Int32
+    property? chat_is_channel : Bool
+    property? chat_is_forum : Bool?
+    property? chat_has_username : Bool?
+    property? chat_is_created : Bool?
+    property user_administrator_rights : ChatAdministratorRights?
+    property bot_administrator_rights : ChatAdministratorRights?
+    property? bot_is_member : Bool?
+    property? request_title : Bool?
+    property? request_username : Bool?
+    property? request_photo : Bool?
+
+    def initialize(
+      @request_id : Int32,
+      @chat_is_channel : Bool,
+      *,
+      @chat_is_forum = nil,
+      @chat_has_username = nil,
+      @chat_is_created = nil,
+      @user_administrator_rights : ChatAdministratorRights? = nil,
+      @bot_administrator_rights : ChatAdministratorRights? = nil,
+      @bot_is_member = nil,
+      @request_title = nil,
+      @request_username = nil,
+      @request_photo = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/keyboard_button_request_managed_bot.cr
+++ b/src/telegram_bot/types/keyboard_button_request_managed_bot.cr
@@ -1,0 +1,17 @@
+module TelegramBot
+  class KeyboardButtonRequestManagedBot
+    include JSON::Serializable
+
+    property request_id : Int32
+    property suggested_name : String?
+    property suggested_username : String?
+
+    def initialize(
+      @request_id : Int32,
+      *,
+      @suggested_name : String? = nil,
+      @suggested_username : String? = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/keyboard_button_request_users.cr
+++ b/src/telegram_bot/types/keyboard_button_request_users.cr
@@ -1,0 +1,25 @@
+module TelegramBot
+  class KeyboardButtonRequestUsers
+    include JSON::Serializable
+
+    property request_id : Int32
+    property? user_is_bot : Bool?
+    property? user_is_premium : Bool?
+    property max_quantity : Int32?
+    property? request_name : Bool?
+    property? request_username : Bool?
+    property? request_photo : Bool?
+
+    def initialize(
+      @request_id : Int32,
+      *,
+      @user_is_bot = nil,
+      @user_is_premium = nil,
+      @max_quantity : Int32? = nil,
+      @request_name = nil,
+      @request_username = nil,
+      @request_photo = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/login_url.cr
+++ b/src/telegram_bot/types/login_url.cr
@@ -1,0 +1,19 @@
+module TelegramBot
+  class LoginUrl
+    include JSON::Serializable
+
+    property url : String
+    property forward_text : String?
+    property bot_username : String?
+    property? request_write_access : Bool?
+
+    def initialize(
+      @url : String,
+      *,
+      @forward_text : String? = nil,
+      @bot_username : String? = nil,
+      @request_write_access = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -55,6 +55,7 @@ module TelegramBot
     property dice : Dice?
     property game : Game?
     property poll : Poll?
+    property web_app_data : WebAppData?
     property location : Location?
     property venue : Venue?
     property new_chat_members : Array(User)?

--- a/src/telegram_bot/types/prepared_inline_message.cr
+++ b/src/telegram_bot/types/prepared_inline_message.cr
@@ -1,0 +1,14 @@
+module TelegramBot
+  class PreparedInlineMessage
+    include JSON::Serializable
+
+    property id : String
+    property expiration_date : Int32
+  end
+
+  class PreparedKeyboardButton
+    include JSON::Serializable
+
+    property id : String
+  end
+end

--- a/src/telegram_bot/types/reply_keyboard_markup.cr
+++ b/src/telegram_bot/types/reply_keyboard_markup.cr
@@ -3,14 +3,28 @@ module TelegramBot
     include JSON::Serializable
 
     property text : String
+    property icon_custom_emoji_id : String?
+    property style : String?
+    property request_users : KeyboardButtonRequestUsers?
+    property request_chat : KeyboardButtonRequestChat?
+    property request_managed_bot : KeyboardButtonRequestManagedBot?
     property? request_contact : Bool?
     property? request_location : Bool?
+    property request_poll : KeyboardButtonPollType?
+    property web_app : WebAppInfo?
 
     def initialize(
       @text : String,
       *,
+      @icon_custom_emoji_id : String? = nil,
+      @style : String? = nil,
+      @request_users : KeyboardButtonRequestUsers? = nil,
+      @request_chat : KeyboardButtonRequestChat? = nil,
+      @request_managed_bot : KeyboardButtonRequestManagedBot? = nil,
       @request_contact = nil,
       @request_location = nil,
+      @request_poll : KeyboardButtonPollType? = nil,
+      @web_app : WebAppInfo? = nil,
     )
     end
   end

--- a/src/telegram_bot/types/switch_inline_query_chosen_chat.cr
+++ b/src/telegram_bot/types/switch_inline_query_chosen_chat.cr
@@ -1,0 +1,21 @@
+module TelegramBot
+  class SwitchInlineQueryChosenChat
+    include JSON::Serializable
+
+    property query : String?
+    property? allow_user_chats : Bool?
+    property? allow_bot_chats : Bool?
+    property? allow_group_chats : Bool?
+    property? allow_channel_chats : Bool?
+
+    def initialize(
+      *,
+      @query : String? = nil,
+      @allow_user_chats = nil,
+      @allow_bot_chats = nil,
+      @allow_group_chats = nil,
+      @allow_channel_chats = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/web_app_info.cr
+++ b/src/telegram_bot/types/web_app_info.cr
@@ -1,0 +1,23 @@
+module TelegramBot
+  class WebAppInfo
+    include JSON::Serializable
+
+    property url : String
+
+    def initialize(@url : String)
+    end
+  end
+
+  class WebAppData
+    include JSON::Serializable
+
+    property data : String
+    property button_text : String
+  end
+
+  class SentWebAppMessage
+    include JSON::Serializable
+
+    property inline_message_id : String?
+  end
+end


### PR DESCRIPTION
## Summary

- Expand inline keyboard buttons with modern Web App, login URL, copy text, inline switch, custom emoji, style, callback game, and pay fields
- Expand reply keyboard buttons with request users/chat/managed bot, poll, Web App, custom emoji, and style fields
- Add keyboard and Web App DTOs, including `LoginUrl`, `WebAppInfo`, `WebAppData`, `SwitchInlineQueryChosenChat`, `CopyTextButton`, keyboard request types, `ChatAdministratorRights`, `PreparedInlineMessage`, and `PreparedKeyboardButton`
- Add Bot API wrappers for `answerWebAppQuery`, `savePreparedInlineMessage`, and `savePreparedKeyboardButton`
- Parse `web_app_data` on messages