### PR TITLE
Add webhook and bot metadata methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ api methods and types:
 - [x] games
 - [x] polls and dice
 - [x] modern keyboard and Web App helpers
-- [ ] webhook metadata and command scopes
+- [x] webhook metadata and command scopes
+- [x] bot profile and default administrator-rights methods
 - [ ] full chat administration methods
 - [ ] Stars, gifts, and paid media methods
 - [ ] full business, guest, and managed bot APIs
@@ -240,6 +241,16 @@ Another option is to use the [`setWebhook`](https://core.telegram.org/bots/api#s
 bot.set_webhook(url, certificate)
 ```
 
+Modern webhook options can be passed as keyword arguments:
+
+```crystal
+bot.set_webhook(
+  "https://example.com/telegram",
+  secret_token: "secret-token",
+  drop_pending_updates: true
+)
+```
+
 After invoking `setWebhook`, have your bot start an HTTPS server with the `serve` command:
 
 ```crystal
@@ -250,10 +261,10 @@ If you run your bot behind a proxy that performs SSL offloading (ie the proxy pr
 
 When running your bot in `serve` mode, the bot will favour executing any methods by sending a response as part of the Telegram request, rather than executing a new request.
 
-Telegram's modern `setWebhook` parameters `ip_address`,
-`drop_pending_updates`, and `secret_token` are not implemented yet. Do not rely
-on `serve` to validate `X-Telegram-Bot-Api-Secret-Token` until that support is
-added.
+`set_webhook` supports Telegram's `secret_token` parameter, but `serve` does not
+validate the `X-Telegram-Bot-Api-Secret-Token` header yet. If you need strict
+validation, terminate webhooks behind middleware or a proxy that checks the
+header before forwarding requests to the bot.
 
 ### Allow/blocklists
 
@@ -284,7 +295,7 @@ types, while unimplemented items are intentionally left out of the public API.
   `save_prepared_inline_message`, `save_prepared_keyboard_button`
 - Callback, games, files, webhooks: `answer_callback_query`, `send_game`,
   `set_game_score`, `get_game_high_scores`, `get_file`, `download`,
-  `set_webhook`, `serve`
+  `set_webhook`, `delete_webhook`, `get_webhook_info`, `serve`
 - Chat basics: `kick_chat_member`, `unban_chat_member`,
   `restrict_chat_member`, `promote_chat_member`, `export_chat_invite_link`,
   `set_chat_photo`, `delete_chat_photo`, `set_chat_title`,
@@ -295,7 +306,11 @@ types, while unimplemented items are intentionally left out of the public API.
   `answer_pre_checkout_query`, `get_sticker_set`, `upload_sticker_file`,
   `create_new_sticker_set`, `add_sticker_to_set`,
   `set_sticker_position_in_set`, `delete_sticker_position_in_set`
-- Bot commands: `set_my_commands`
+- Bot commands and profile: `set_my_commands`, `get_my_commands`,
+  `delete_my_commands`, `set_my_name`, `get_my_name`, `set_my_description`,
+  `get_my_description`, `set_my_short_description`,
+  `get_my_short_description`, `set_my_default_administrator_rights`,
+  `get_my_default_administrator_rights`
 
 ### Implemented update handlers
 
@@ -349,14 +364,20 @@ Override these methods in your bot subclass:
   `KeyboardButtonRequestManagedBot`, `KeyboardButtonPollType`,
   `ChatAdministratorRights`, `SentWebAppMessage`, `PreparedInlineMessage`,
   `PreparedKeyboardButton`
+- Webhook, command scope, and bot profile: `WebhookInfo`,
+  `BotCommandScopeDefault`, `BotCommandScopeAllPrivateChats`,
+  `BotCommandScopeAllGroupChats`, `BotCommandScopeAllChatAdministrators`,
+  `BotCommandScopeChat`, `BotCommandScopeChatAdministrators`,
+  `BotCommandScopeChatMember`, `BotName`, `BotDescription`,
+  `BotShortDescription`
 - Selected business and managed bot update containers:
   `BusinessConnection`, `BusinessMessagesDeleted`, `PaidMediaPurchased`,
   `ChatBoostUpdated`, `ChatBoostRemoved`, `ManagedBotUpdated`
 
 ### Not implemented yet
 
-- `get_webhook_info`, modern `set_webhook` options, `delete_webhook`, command
-  scopes, and bot profile/default administrator-rights methods
+- Webhook secret-token validation in `serve`
+- Profile photo and chat menu button methods
 - Full modern chat administration, invite link, join request, forum management,
   and reaction management methods
 - Stars, gifts, paid media methods, and their full type graph

--- a/TODO.md
+++ b/TODO.md
@@ -163,30 +163,30 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 6: Webhook And Bot Metadata Methods
 
-- [ ] Add `get_webhook_info` and `WebhookInfo`.
-- [ ] Extend `set_webhook` with:
-  - [ ] `ip_address`
-  - [ ] `drop_pending_updates`
-  - [ ] `secret_token`
-- [ ] Extend `delete_webhook` with `drop_pending_updates`.
-- [ ] Add command scopes:
-  - [ ] `BotCommandScopeDefault`
-  - [ ] `BotCommandScopeAllPrivateChats`
-  - [ ] `BotCommandScopeAllGroupChats`
-  - [ ] `BotCommandScopeAllChatAdministrators`
-  - [ ] `BotCommandScopeChat`
-  - [ ] `BotCommandScopeChatAdministrators`
-  - [ ] `BotCommandScopeChatMember`
-- [ ] Extend `set_my_commands` and `get_my_commands` with `scope` and
+- [x] Add `get_webhook_info` and `WebhookInfo`.
+- [x] Extend `set_webhook` with:
+  - [x] `ip_address`
+  - [x] `drop_pending_updates`
+  - [x] `secret_token`
+- [x] Extend `delete_webhook` with `drop_pending_updates`.
+- [x] Add command scopes:
+  - [x] `BotCommandScopeDefault`
+  - [x] `BotCommandScopeAllPrivateChats`
+  - [x] `BotCommandScopeAllGroupChats`
+  - [x] `BotCommandScopeAllChatAdministrators`
+  - [x] `BotCommandScopeChat`
+  - [x] `BotCommandScopeChatAdministrators`
+  - [x] `BotCommandScopeChatMember`
+- [x] Extend `set_my_commands` and `get_my_commands` with `scope` and
       `language_code`.
-- [ ] Add `delete_my_commands`.
-- [ ] Add bot profile methods and types:
-  - [ ] `set_my_name`, `get_my_name`, `BotName`
-  - [ ] `set_my_description`, `get_my_description`, `BotDescription`
-  - [ ] `set_my_short_description`, `get_my_short_description`,
+- [x] Add `delete_my_commands`.
+- [x] Add bot profile methods and types:
+  - [x] `set_my_name`, `get_my_name`, `BotName`
+  - [x] `set_my_description`, `get_my_description`, `BotDescription`
+  - [x] `set_my_short_description`, `get_my_short_description`,
         `BotShortDescription`
-  - [ ] `set_my_default_administrator_rights`
-  - [ ] `get_my_default_administrator_rights`
+  - [x] `set_my_default_administrator_rights`
+  - [x] `get_my_default_administrator_rights`
 
 ## Phase 7: Chat Administration
 
@@ -334,7 +334,7 @@ keeping backward-compatible method signatures where practical.
   - [x] inline keyboard callback bot
   - [x] poll bot
   - [x] forum topic bot
-  - [x] webhook with `secret_token` compatibility note
+  - [x] webhook with `secret_token`
 - [x] Add a support matrix listing implemented methods and types.
 - [x] Decide whether to keep deprecated Telegram API aliases or mark them with
       comments before removal in a future major release.

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -3,6 +3,37 @@ require "./spec_helper"
 class RequestBuildingBot < TelegramBot::Bot
   getter last_method, last_force_http, last_params, handled_update
 
+  TRUE_METHODS = [
+    "answerInlineQuery",
+    "answerShippingQuery",
+    "answerPreCheckoutQuery",
+    "pinChatMessage",
+    "unpinChatMessage",
+    "sendMessageDraft",
+    "setMyCommands",
+    "deleteMyCommands",
+    "setMyName",
+    "setMyDescription",
+    "setMyShortDescription",
+    "setMyDefaultAdministratorRights",
+    "deleteWebhook",
+  ]
+
+  METHOD_RESPONSES = {
+    "getMyCommands"                   => %([{"command":"start","description":"Start"}]),
+    "getMyName"                       => %({"name":"Test Bot"}),
+    "getMyDescription"                => %({"description":"Long description"}),
+    "getMyShortDescription"           => %({"short_description":"Short description"}),
+    "getMyDefaultAdministratorRights" => %({"can_delete_messages":true}),
+    "getWebhookInfo"                  => %({"url":"https://example.com/hook","has_custom_certificate":false,"pending_update_count":3,"ip_address":"127.0.0.1","max_connections":40,"allowed_updates":["message"]}),
+    "answerWebAppQuery"               => %({"inline_message_id":"inline-id"}),
+    "savePreparedInlineMessage"       => %({"id":"prepared-inline-id","expiration_date":1800000000}),
+    "savePreparedKeyboardButton"      => %({"id":"prepared-keyboard-id"}),
+    "copyMessage"                     => %({"message_id":100}),
+    "copyMessages"                    => %([{"message_id":100},{"message_id":101}]),
+    "forwardMessages"                 => %([{"message_id":100},{"message_id":101}]),
+  }
+
   def initialize
     super "testbot", "token"
     @last_method = nil.as(String?)
@@ -20,19 +51,10 @@ class RequestBuildingBot < TelegramBot::Bot
       @last_params[key] = value.nil? ? nil : value.to_s
     end
 
-    case method
-    when "answerInlineQuery", "answerShippingQuery", "answerPreCheckoutQuery", "pinChatMessage", "unpinChatMessage", "sendMessageDraft", "setMyCommands"
+    if TRUE_METHODS.includes?(method)
       JSON.parse("true")
-    when "answerWebAppQuery"
-      JSON.parse(%({"inline_message_id":"inline-id"}))
-    when "savePreparedInlineMessage"
-      JSON.parse(%({"id":"prepared-inline-id","expiration_date":1800000000}))
-    when "savePreparedKeyboardButton"
-      JSON.parse(%({"id":"prepared-keyboard-id"}))
-    when "copyMessage"
-      JSON.parse(%({"message_id":100}))
-    when "copyMessages", "forwardMessages"
-      JSON.parse(%([{"message_id":100},{"message_id":101}]))
+    elsif response = METHOD_RESPONSES[method]?
+      JSON.parse(response)
     else
       JSON.parse(%({"message_id":1,"date":0,"chat":{"id":1,"type":"private"}}))
     end
@@ -485,6 +507,100 @@ describe TelegramBot::Bot do
     prepared_button.id.should eq("prepared-keyboard-id")
     bot.last_method.should eq("savePreparedKeyboardButton")
     bot.param("button").should contain("KeyboardButton")
+  end
+
+  it "serializes bot command scopes" do
+    bot = RequestBuildingBot.new
+    commands = [TelegramBot::BotCommand.new("start", "Start")]
+    scope = TelegramBot::BotCommandScopeChatMember.new("@group", 123)
+
+    bot.set_my_commands(commands, scope: scope, language_code: "en")
+
+    bot.last_method.should eq("setMyCommands")
+    bot.param("commands").should contain("BotCommand")
+    bot.param("scope").should contain("BotCommandScopeChatMember")
+    bot.last_params["language_code"].should eq("en")
+
+    params = bot.serialize_for_spec({"scope" => scope})
+    JSON.parse(params["scope"].as(String)).should eq(JSON.parse(<<-JSON))
+      {
+        "type": "chat_member",
+        "chat_id": "@group",
+        "user_id": 123
+      }
+      JSON
+  end
+
+  it "builds bot command metadata methods" do
+    bot = RequestBuildingBot.new
+    scope = TelegramBot::BotCommandScopeAllPrivateChats.new
+
+    commands = bot.get_my_commands(scope: scope, language_code: "en")
+
+    commands.first.command.should eq("start")
+    bot.last_method.should eq("getMyCommands")
+    bot.last_force_http.should be_true
+    bot.param("scope").should contain("BotCommandScopeAllPrivateChats")
+    bot.last_params["language_code"].should eq("en")
+
+    deleted = bot.delete_my_commands(scope: scope)
+
+    deleted.should be_true
+    bot.last_method.should eq("deleteMyCommands")
+    bot.last_force_http.should be_true
+  end
+
+  it "builds webhook metadata methods" do
+    bot = RequestBuildingBot.new
+
+    deleted = bot.delete_webhook(drop_pending_updates: true)
+
+    deleted.should be_true
+    bot.last_method.should eq("deleteWebhook")
+    bot.last_force_http.should be_true
+    bot.last_params["drop_pending_updates"].should eq("true")
+
+    info = bot.get_webhook_info
+
+    info.url.should eq("https://example.com/hook")
+    info.has_custom_certificate?.should be_false
+    info.pending_update_count.should eq(3)
+    info.ip_address.should eq("127.0.0.1")
+    info.allowed_updates.should eq(["message"])
+    bot.last_method.should eq("getWebhookInfo")
+    bot.last_force_http.should be_true
+  end
+
+  it "builds bot profile and default administrator rights methods" do
+    bot = RequestBuildingBot.new
+
+    bot.set_my_name("Test Bot", language_code: "en").should be_true
+    bot.last_method.should eq("setMyName")
+    bot.last_force_http.should be_true
+    bot.last_params["name"].should eq("Test Bot")
+    bot.last_params["language_code"].should eq("en")
+
+    bot.get_my_name(language_code: "en").name.should eq("Test Bot")
+    bot.last_method.should eq("getMyName")
+    bot.last_params["language_code"].should eq("en")
+
+    bot.set_my_description("Long description").should be_true
+    bot.last_method.should eq("setMyDescription")
+    bot.get_my_description.description.should eq("Long description")
+
+    bot.set_my_short_description("Short description").should be_true
+    bot.last_method.should eq("setMyShortDescription")
+    bot.get_my_short_description.short_description.should eq("Short description")
+
+    rights = TelegramBot::ChatAdministratorRights.new(can_delete_messages: true)
+    bot.set_my_default_administrator_rights(rights, for_channels: true).should be_true
+    bot.last_method.should eq("setMyDefaultAdministratorRights")
+    bot.param("rights").should contain("ChatAdministratorRights")
+    bot.last_params["for_channels"].should eq("true")
+
+    bot.get_my_default_administrator_rights(for_channels: true).can_delete_messages?.should be_true
+    bot.last_method.should eq("getMyDefaultAdministratorRights")
+    bot.last_force_http.should be_true
   end
 
   it "builds multipart bodies with serialized non-file params" do

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -1127,17 +1127,35 @@ module TelegramBot
       HTTP::Client.get("https://api.telegram.org/file/bot#{@token}/#{file_path}").body
     end
 
-    def set_webhook(url : String, certificate : ::File | String? = nil, max_connections : Int32? = nil, allowed_updates : Array(String)? = @allowed_updates)
-      multipart_params = HTTP::Client::MultipartBody.new(serialize_params({"url" => url, "max_connections" => max_connections, "allowed_updates" => allowed_updates}))
+    def set_webhook(url : String,
+                    certificate : ::File | String? = nil,
+                    max_connections : Int32? = nil,
+                    allowed_updates : Array(String)? = @allowed_updates,
+                    ip_address : String? = nil,
+                    drop_pending_updates : Bool? = nil,
+                    secret_token : String? = nil)
+      multipart_params = HTTP::Client::MultipartBody.new(serialize_params({
+        "url"                  => url,
+        "max_connections"      => max_connections,
+        "allowed_updates"      => allowed_updates,
+        "ip_address"           => ip_address,
+        "drop_pending_updates" => drop_pending_updates,
+        "secret_token"         => secret_token,
+      }))
       multipart_params.add_file("certificate", certificate, filename: "cert.pem") if certificate
       Log.info { "Setting webhook to '#{url}'#{" with certificate" if certificate}" }
       response = HttpClient.new(@token).post_multipart "setWebhook", multipart_params
       handle_http_response(response)
     end
 
-    def delete_webhook : Bool?
-      res = request "deleteWebhook", force_http: true
+    def delete_webhook(drop_pending_updates : Bool? = nil) : Bool?
+      res = def_force_request "deleteWebhook", drop_pending_updates
       res.as_bool if res
+    end
+
+    def get_webhook_info : WebhookInfo
+      res = request "getWebhookInfo", force_http: true
+      WebhookInfo.from_json(res.to_json)
     end
 
     #
@@ -1270,8 +1288,9 @@ module TelegramBot
     end
 
     # Get the current list of the bot's commands.
-    def get_my_commands : Array(BotCommand)
-      res = request "getMyCommands"
+    def get_my_commands(scope : BotCommandScope? = nil,
+                        language_code : String? = nil) : Array(BotCommand)
+      res = def_force_request "getMyCommands", scope, language_code
       res = res.not_nil!.as_a
       commands = Array(BotCommand).new
       res.each { |command| commands << BotCommand.from_json(command.to_json) }
@@ -1279,9 +1298,61 @@ module TelegramBot
     end
 
     # Change the list of the bot's commands.
-    def set_my_commands(commands : Array(BotCommand))
-      res = def_request "setMyCommands", commands
+    def set_my_commands(commands : Array(BotCommand),
+                        scope : BotCommandScope? = nil,
+                        language_code : String? = nil)
+      res = def_request "setMyCommands", commands, scope, language_code
       res.as_bool if res
+    end
+
+    def delete_my_commands(scope : BotCommandScope? = nil,
+                           language_code : String? = nil)
+      res = def_force_request "deleteMyCommands", scope, language_code
+      res.as_bool if res
+    end
+
+    def set_my_name(name : String? = nil,
+                    language_code : String? = nil)
+      res = def_force_request "setMyName", name, language_code
+      res.as_bool if res
+    end
+
+    def get_my_name(language_code : String? = nil) : BotName
+      res = def_force_request "getMyName", language_code
+      BotName.from_json(res.to_json)
+    end
+
+    def set_my_description(description : String? = nil,
+                           language_code : String? = nil)
+      res = def_force_request "setMyDescription", description, language_code
+      res.as_bool if res
+    end
+
+    def get_my_description(language_code : String? = nil) : BotDescription
+      res = def_force_request "getMyDescription", language_code
+      BotDescription.from_json(res.to_json)
+    end
+
+    def set_my_short_description(short_description : String? = nil,
+                                 language_code : String? = nil)
+      res = def_force_request "setMyShortDescription", short_description, language_code
+      res.as_bool if res
+    end
+
+    def get_my_short_description(language_code : String? = nil) : BotShortDescription
+      res = def_force_request "getMyShortDescription", language_code
+      BotShortDescription.from_json(res.to_json)
+    end
+
+    def set_my_default_administrator_rights(rights : ChatAdministratorRights? = nil,
+                                            for_channels : Bool? = nil)
+      res = def_force_request "setMyDefaultAdministratorRights", rights, for_channels
+      res.as_bool if res
+    end
+
+    def get_my_default_administrator_rights(for_channels : Bool? = nil) : ChatAdministratorRights
+      res = def_force_request "getMyDefaultAdministratorRights", for_channels
+      ChatAdministratorRights.from_json(res.to_json)
     end
   end
 end

--- a/src/telegram_bot/types/bot_command_scope.cr
+++ b/src/telegram_bot/types/bot_command_scope.cr
@@ -1,0 +1,75 @@
+module TelegramBot
+  abstract class BotCommandScope
+    def to_json(json : JSON::Builder)
+      raise "BotCommandScope subclasses must implement JSON serialization"
+    end
+  end
+
+  class BotCommandScopeDefault < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "default"
+
+    def initialize
+    end
+  end
+
+  class BotCommandScopeAllPrivateChats < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "all_private_chats"
+
+    def initialize
+    end
+  end
+
+  class BotCommandScopeAllGroupChats < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "all_group_chats"
+
+    def initialize
+    end
+  end
+
+  class BotCommandScopeAllChatAdministrators < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "all_chat_administrators"
+
+    def initialize
+    end
+  end
+
+  class BotCommandScopeChat < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "chat"
+    property chat_id : Int32 | Int64 | String
+
+    def initialize(@chat_id : Int32 | Int64 | String)
+    end
+  end
+
+  class BotCommandScopeChatAdministrators < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "chat_administrators"
+    property chat_id : Int32 | Int64 | String
+
+    def initialize(@chat_id : Int32 | Int64 | String)
+    end
+  end
+
+  class BotCommandScopeChatMember < BotCommandScope
+    include JSON::Serializable
+
+    property type : String = "chat_member"
+    property chat_id : Int32 | Int64 | String
+    property user_id : Int64
+
+    def initialize(@chat_id : Int32 | Int64 | String, user_id : Int32 | Int64)
+      @user_id = user_id.to_i64
+    end
+  end
+end

--- a/src/telegram_bot/types/bot_profile.cr
+++ b/src/telegram_bot/types/bot_profile.cr
@@ -1,0 +1,19 @@
+module TelegramBot
+  class BotName
+    include JSON::Serializable
+
+    property name : String
+  end
+
+  class BotDescription
+    include JSON::Serializable
+
+    property description : String
+  end
+
+  class BotShortDescription
+    include JSON::Serializable
+
+    property short_description : String
+  end
+end

--- a/src/telegram_bot/types/webhook_info.cr
+++ b/src/telegram_bot/types/webhook_info.cr
@@ -1,0 +1,15 @@
+module TelegramBot
+  class WebhookInfo
+    include JSON::Serializable
+
+    property url : String
+    property? has_custom_certificate : Bool
+    property pending_update_count : Int32
+    property ip_address : String?
+    property last_error_date : Int32?
+    property last_error_message : String?
+    property last_synchronization_error_date : Int32?
+    property max_connections : Int32?
+    property allowed_updates : Array(String)?
+  end
+end


### PR DESCRIPTION
## Summary

- Add `WebhookInfo` and `get_webhook_info`
- Extend `set_webhook` with `ip_address`, `drop_pending_updates`, and `secret_token`
- Extend `delete_webhook` with `drop_pending_updates`
- Add command scope types and scoped command methods:
  - `BotCommandScopeDefault`
  - `BotCommandScopeAllPrivateChats`
  - `BotCommandScopeAllGroupChats`
  - `BotCommandScopeAllChatAdministrators`
  - `BotCommandScopeChat`
  - `BotCommandScopeChatAdministrators`
  - `BotCommandScopeChatMember`
  - `set_my_commands`
  - `get_my_commands`
  - `delete_my_commands`
- Add bot profile/default rights methods and types:
  - `set_my_name`, `get_my_name`, `BotName`
  - `set_my_description`, `get_my_description`, `BotDescription`
  - `set_my_short_description`, `get_my_short_description`, `BotShortDescription`
  - `set_my_default_administrator_rights`
  - `get_my_default_administrator_rights`