### PR TITLE
Add chat administration methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ api methods and types:
 - [x] modern keyboard and Web App helpers
 - [x] webhook metadata and command scopes
 - [x] bot profile and default administrator-rights methods
-- [ ] full chat administration methods
+- [x] invite link, join request, forum topic, and reaction methods
 - [ ] Stars, gifts, and paid media methods
 - [ ] full business, guest, and managed bot APIs
 
@@ -298,10 +298,22 @@ types, while unimplemented items are intentionally left out of the public API.
   `set_webhook`, `delete_webhook`, `get_webhook_info`, `serve`
 - Chat basics: `kick_chat_member`, `unban_chat_member`,
   `restrict_chat_member`, `promote_chat_member`, `export_chat_invite_link`,
+  `create_chat_invite_link`, `edit_chat_invite_link`,
+  `create_chat_subscription_invite_link`,
+  `edit_chat_subscription_invite_link`, `revoke_chat_invite_link`,
+  `approve_chat_join_request`, `decline_chat_join_request`,
   `set_chat_photo`, `delete_chat_photo`, `set_chat_title`,
   `set_chat_description`, `pin_chat_message`, `unpin_chat_message`,
   `get_chat`, `leave_chat`, `get_chat_administrators`, `get_chat_member`,
   `get_chat_members_count`, `set_chat_sticker_set`, `delete_chat_sticker_set`
+- Forum and reactions: `get_forum_topic_icon_stickers`,
+  `create_forum_topic`, `edit_forum_topic`, `close_forum_topic`,
+  `reopen_forum_topic`, `delete_forum_topic`,
+  `unpin_all_forum_topic_messages`, `edit_general_forum_topic`,
+  `close_general_forum_topic`, `reopen_general_forum_topic`,
+  `hide_general_forum_topic`, `unhide_general_forum_topic`,
+  `unpin_all_general_forum_topic_messages`, `set_message_reaction`,
+  `delete_message_reaction`, `delete_all_message_reactions`
 - Payments and stickers: `send_invoice`, `answer_shipping_query`,
   `answer_pre_checkout_query`, `get_sticker_set`, `upload_sticker_file`,
   `create_new_sticker_set`, `add_sticker_to_set`,
@@ -357,6 +369,8 @@ Override these methods in your bot subclass:
   `ForumTopicCreated`, `ForumTopicEdited`, `ForumTopicClosed`,
   `ForumTopicReopened`, `GeneralForumTopicHidden`,
   `GeneralForumTopicUnhidden`
+- Chat administration: `ChatPermissions`, `ChatMember`,
+  `ChatMemberUpdated`, `ChatInviteLink`, `ChatJoinRequest`
 - Keyboards and Web Apps: `InlineKeyboardButton`, `InlineKeyboardMarkup`,
   `KeyboardButton`, `ReplyKeyboardMarkup`, `LoginUrl`, `WebAppInfo`,
   `WebAppData`, `SwitchInlineQueryChosenChat`, `CopyTextButton`,
@@ -378,8 +392,8 @@ Override these methods in your bot subclass:
 
 - Webhook secret-token validation in `serve`
 - Profile photo and chat menu button methods
-- Full modern chat administration, invite link, join request, forum management,
-  and reaction management methods
+- Newer chat administration APIs outside Phase 7, such as `set_chat_member_tag`
+  and user profile audio methods
 - Stars, gifts, paid media methods, and their full type graph
 - Full business, guest, and managed bot method/type support
 

--- a/TODO.md
+++ b/TODO.md
@@ -190,44 +190,44 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 7: Chat Administration
 
-- [ ] Add `ChatPermissions`.
-- [ ] Add modern `ChatMember` variants or expand current `ChatMember`:
-  - [ ] owner
-  - [ ] administrator
-  - [ ] member
-  - [ ] restricted
-  - [ ] left
-  - [ ] banned
-- [ ] Add `ChatMemberUpdated`.
-- [ ] Add `ChatInviteLink`.
-- [ ] Add `ChatJoinRequest`.
-- [ ] Add invite link methods:
-  - [ ] `create_chat_invite_link`
-  - [ ] `edit_chat_invite_link`
-  - [ ] `create_chat_subscription_invite_link`
-  - [ ] `edit_chat_subscription_invite_link`
-  - [ ] `revoke_chat_invite_link`
-- [ ] Add join request methods:
-  - [ ] `approve_chat_join_request`
-  - [ ] `decline_chat_join_request`
-- [ ] Add forum methods:
-  - [ ] `get_forum_topic_icon_stickers`
-  - [ ] `create_forum_topic`
-  - [ ] `edit_forum_topic`
-  - [ ] `close_forum_topic`
-  - [ ] `reopen_forum_topic`
-  - [ ] `delete_forum_topic`
-  - [ ] `unpin_all_forum_topic_messages`
-  - [ ] `edit_general_forum_topic`
-  - [ ] `close_general_forum_topic`
-  - [ ] `reopen_general_forum_topic`
-  - [ ] `hide_general_forum_topic`
-  - [ ] `unhide_general_forum_topic`
-  - [ ] `unpin_all_general_forum_topic_messages`
-- [ ] Add reaction methods:
-  - [ ] `set_message_reaction`
-  - [ ] `delete_message_reaction`
-  - [ ] `delete_all_message_reactions`
+- [x] Add `ChatPermissions`.
+- [x] Add modern `ChatMember` variants or expand current `ChatMember`:
+  - [x] owner
+  - [x] administrator
+  - [x] member
+  - [x] restricted
+  - [x] left
+  - [x] banned
+- [x] Add `ChatMemberUpdated`.
+- [x] Add `ChatInviteLink`.
+- [x] Add `ChatJoinRequest`.
+- [x] Add invite link methods:
+  - [x] `create_chat_invite_link`
+  - [x] `edit_chat_invite_link`
+  - [x] `create_chat_subscription_invite_link`
+  - [x] `edit_chat_subscription_invite_link`
+  - [x] `revoke_chat_invite_link`
+- [x] Add join request methods:
+  - [x] `approve_chat_join_request`
+  - [x] `decline_chat_join_request`
+- [x] Add forum methods:
+  - [x] `get_forum_topic_icon_stickers`
+  - [x] `create_forum_topic`
+  - [x] `edit_forum_topic`
+  - [x] `close_forum_topic`
+  - [x] `reopen_forum_topic`
+  - [x] `delete_forum_topic`
+  - [x] `unpin_all_forum_topic_messages`
+  - [x] `edit_general_forum_topic`
+  - [x] `close_general_forum_topic`
+  - [x] `reopen_general_forum_topic`
+  - [x] `hide_general_forum_topic`
+  - [x] `unhide_general_forum_topic`
+  - [x] `unpin_all_general_forum_topic_messages`
+- [x] Add reaction methods:
+  - [x] `set_message_reaction`
+  - [x] `delete_message_reaction`
+  - [x] `delete_all_message_reactions`
 
 ## Phase 8: Keyboard, Inline, And Web App Support
 

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -138,3 +138,59 @@ describe TelegramBot::ForumTopic do
     topic.icon_custom_emoji_id.should eq("emoji-id")
   end
 end
+
+describe TelegramBot::ChatMember do
+  it "parses modern member and invite link fields" do
+    member = TelegramBot::ChatMember.from_json(<<-JSON)
+      {
+        "status": "restricted",
+        "user": {"id": 1, "is_bot": false, "first_name": "User"},
+        "is_member": true,
+        "can_send_messages": true,
+        "can_send_photos": true,
+        "can_react_to_messages": true,
+        "until_date": 1800000000
+      }
+      JSON
+    link = TelegramBot::ChatInviteLink.from_json(<<-JSON)
+      {
+        "invite_link": "https://t.me/+invite",
+        "creator": {"id": 2, "is_bot": true, "first_name": "Bot"},
+        "creates_join_request": true,
+        "is_primary": false,
+        "is_revoked": false,
+        "subscription_period": 2592000,
+        "subscription_price": 100
+      }
+      JSON
+    update = TelegramBot::ChatMemberUpdated.from_json(<<-JSON)
+      {
+        "chat": {"id": -100, "type": "supergroup", "title": "Group"},
+        "from": {"id": 3, "is_bot": false, "first_name": "Admin"},
+        "date": 0,
+        "old_chat_member": {
+          "status": "left",
+          "user": {"id": 1, "is_bot": false, "first_name": "User"}
+        },
+        "new_chat_member": {
+          "status": "member",
+          "user": {"id": 1, "is_bot": false, "first_name": "User"}
+        },
+        "invite_link": {
+          "invite_link": "https://t.me/+invite",
+          "creator": {"id": 2, "is_bot": true, "first_name": "Bot"},
+          "creates_join_request": false,
+          "is_primary": false,
+          "is_revoked": false
+        }
+      }
+      JSON
+
+    member.status.should eq("restricted")
+    member.is_member?.should be_true
+    member.can_send_photos?.should be_true
+    member.can_react_to_messages?.should be_true
+    link.subscription_price.should eq(100)
+    update.invite_link.try(&.invite_link).should eq("https://t.me/+invite")
+  end
+end

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -17,21 +17,45 @@ class RequestBuildingBot < TelegramBot::Bot
     "setMyShortDescription",
     "setMyDefaultAdministratorRights",
     "deleteWebhook",
+    "restrictChatMember",
+    "approveChatJoinRequest",
+    "declineChatJoinRequest",
+    "setMessageReaction",
+    "deleteMessageReaction",
+    "deleteAllMessageReactions",
+    "editForumTopic",
+    "closeForumTopic",
+    "reopenForumTopic",
+    "deleteForumTopic",
+    "unpinAllForumTopicMessages",
+    "editGeneralForumTopic",
+    "closeGeneralForumTopic",
+    "reopenGeneralForumTopic",
+    "hideGeneralForumTopic",
+    "unhideGeneralForumTopic",
+    "unpinAllGeneralForumTopicMessages",
   ]
 
   METHOD_RESPONSES = {
-    "getMyCommands"                   => %([{"command":"start","description":"Start"}]),
-    "getMyName"                       => %({"name":"Test Bot"}),
-    "getMyDescription"                => %({"description":"Long description"}),
-    "getMyShortDescription"           => %({"short_description":"Short description"}),
-    "getMyDefaultAdministratorRights" => %({"can_delete_messages":true}),
-    "getWebhookInfo"                  => %({"url":"https://example.com/hook","has_custom_certificate":false,"pending_update_count":3,"ip_address":"127.0.0.1","max_connections":40,"allowed_updates":["message"]}),
-    "answerWebAppQuery"               => %({"inline_message_id":"inline-id"}),
-    "savePreparedInlineMessage"       => %({"id":"prepared-inline-id","expiration_date":1800000000}),
-    "savePreparedKeyboardButton"      => %({"id":"prepared-keyboard-id"}),
-    "copyMessage"                     => %({"message_id":100}),
-    "copyMessages"                    => %([{"message_id":100},{"message_id":101}]),
-    "forwardMessages"                 => %([{"message_id":100},{"message_id":101}]),
+    "getMyCommands"                    => %([{"command":"start","description":"Start"}]),
+    "getMyName"                        => %({"name":"Test Bot"}),
+    "getMyDescription"                 => %({"description":"Long description"}),
+    "getMyShortDescription"            => %({"short_description":"Short description"}),
+    "getMyDefaultAdministratorRights"  => %({"can_delete_messages":true}),
+    "getWebhookInfo"                   => %({"url":"https://example.com/hook","has_custom_certificate":false,"pending_update_count":3,"ip_address":"127.0.0.1","max_connections":40,"allowed_updates":["message"]}),
+    "answerWebAppQuery"                => %({"inline_message_id":"inline-id"}),
+    "savePreparedInlineMessage"        => %({"id":"prepared-inline-id","expiration_date":1800000000}),
+    "savePreparedKeyboardButton"       => %({"id":"prepared-keyboard-id"}),
+    "copyMessage"                      => %({"message_id":100}),
+    "copyMessages"                     => %([{"message_id":100},{"message_id":101}]),
+    "forwardMessages"                  => %([{"message_id":100},{"message_id":101}]),
+    "createChatInviteLink"             => %({"invite_link":"https://t.me/+invite","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":true,"is_primary":false,"is_revoked":false,"name":"Invite"}),
+    "editChatInviteLink"               => %({"invite_link":"https://t.me/+invite","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":false,"name":"Edited"}),
+    "createChatSubscriptionInviteLink" => %({"invite_link":"https://t.me/+sub","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":false,"subscription_period":2592000,"subscription_price":100}),
+    "editChatSubscriptionInviteLink"   => %({"invite_link":"https://t.me/+sub","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":false,"name":"Sub"}),
+    "revokeChatInviteLink"             => %({"invite_link":"https://t.me/+invite","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":true}),
+    "getForumTopicIconStickers"        => %([{"file_id":"sticker-id","width":512,"height":512}]),
+    "createForumTopic"                 => %({"message_thread_id":42,"name":"Topic","icon_color":7322096,"icon_custom_emoji_id":"emoji-id"}),
   }
 
   def initialize
@@ -601,6 +625,106 @@ describe TelegramBot::Bot do
     bot.get_my_default_administrator_rights(for_channels: true).can_delete_messages?.should be_true
     bot.last_method.should eq("getMyDefaultAdministratorRights")
     bot.last_force_http.should be_true
+  end
+
+  it "builds chat permissions, join request, and invite link methods" do
+    bot = RequestBuildingBot.new
+    permissions = TelegramBot::ChatPermissions.new(
+      can_send_messages: true,
+      can_send_photos: true,
+      can_react_to_messages: true
+    )
+
+    bot.restrict_chat_member("@group", 123, permissions: permissions, use_independent_chat_permissions: true)
+
+    bot.last_method.should eq("restrictChatMember")
+    bot.param("permissions").should contain("ChatPermissions")
+    bot.last_params["use_independent_chat_permissions"].should eq("true")
+
+    bot.restrict_chat_member("@group", 123, can_send_media_messages: true)
+    bot.param("permissions").should contain("can_send_photos")
+
+    invite = bot.create_chat_invite_link("@group", name: "Invite", creates_join_request: true)
+
+    invite.try(&.invite_link).should eq("https://t.me/+invite")
+    invite.try(&.creates_join_request?).should be_true
+    bot.last_method.should eq("createChatInviteLink")
+    bot.last_params["name"].should eq("Invite")
+
+    edited = bot.edit_chat_invite_link("@group", "https://t.me/+invite", name: "Edited")
+    edited.try(&.name).should eq("Edited")
+    bot.last_method.should eq("editChatInviteLink")
+
+    subscription = bot.create_chat_subscription_invite_link("@channel", 2_592_000, 100, name: "Sub")
+    subscription.try(&.subscription_price).should eq(100)
+    bot.last_method.should eq("createChatSubscriptionInviteLink")
+
+    revoked = bot.revoke_chat_invite_link("@group", "https://t.me/+invite")
+    revoked.try(&.is_revoked?).should be_true
+    bot.last_method.should eq("revokeChatInviteLink")
+
+    bot.approve_chat_join_request("@group", 123).should be_true
+    bot.last_method.should eq("approveChatJoinRequest")
+    bot.decline_chat_join_request("@group", 123).should be_true
+    bot.last_method.should eq("declineChatJoinRequest")
+
+    JSON.parse(permissions.to_json).should eq(JSON.parse(<<-JSON))
+      {
+        "can_send_messages": true,
+        "can_send_photos": true,
+        "can_react_to_messages": true
+      }
+      JSON
+  end
+
+  it "builds forum topic and reaction methods" do
+    bot = RequestBuildingBot.new
+    reaction = TelegramBot::ReactionTypeEmoji.new("👍")
+
+    bot.set_message_reaction("@group", 10, [reaction] of TelegramBot::ReactionType, is_big: true).should be_true
+    bot.last_method.should eq("setMessageReaction")
+    bot.param("reaction").should contain("ReactionTypeEmoji")
+    bot.last_params["is_big"].should eq("true")
+
+    bot.delete_message_reaction("@group", 10, reaction).should be_true
+    bot.last_method.should eq("deleteMessageReaction")
+    bot.param("reaction").should contain("ReactionTypeEmoji")
+
+    bot.delete_all_message_reactions("@group", 10).should be_true
+    bot.last_method.should eq("deleteAllMessageReactions")
+
+    stickers = bot.get_forum_topic_icon_stickers
+    stickers.first.file_id.should eq("sticker-id")
+    bot.last_method.should eq("getForumTopicIconStickers")
+    bot.last_force_http.should be_true
+
+    topic = bot.create_forum_topic("@group", "Topic", icon_color: 7_322_096, icon_custom_emoji_id: "emoji-id")
+    topic.try(&.message_thread_id).should eq(42)
+    bot.last_method.should eq("createForumTopic")
+
+    bot.edit_forum_topic("@group", 42, name: "New Topic").should be_true
+    bot.last_method.should eq("editForumTopic")
+    bot.close_forum_topic("@group", 42).should be_true
+    bot.last_method.should eq("closeForumTopic")
+    bot.reopen_forum_topic("@group", 42).should be_true
+    bot.last_method.should eq("reopenForumTopic")
+    bot.delete_forum_topic("@group", 42).should be_true
+    bot.last_method.should eq("deleteForumTopic")
+    bot.unpin_all_forum_topic_messages("@group", 42).should be_true
+    bot.last_method.should eq("unpinAllForumTopicMessages")
+
+    bot.edit_general_forum_topic("@group", "General").should be_true
+    bot.last_method.should eq("editGeneralForumTopic")
+    bot.close_general_forum_topic("@group").should be_true
+    bot.last_method.should eq("closeGeneralForumTopic")
+    bot.reopen_general_forum_topic("@group").should be_true
+    bot.last_method.should eq("reopenGeneralForumTopic")
+    bot.hide_general_forum_topic("@group").should be_true
+    bot.last_method.should eq("hideGeneralForumTopic")
+    bot.unhide_general_forum_topic("@group").should be_true
+    bot.last_method.should eq("unhideGeneralForumTopic")
+    bot.unpin_all_general_forum_topic_messages("@group").should be_true
+    bot.last_method.should eq("unpinAllGeneralForumTopicMessages")
   end
 
   it "builds multipart bodies with serialized non-file params" do

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -642,7 +642,25 @@ describe TelegramBot::Bot do
     bot.last_params["use_independent_chat_permissions"].should eq("true")
 
     bot.restrict_chat_member("@group", 123, can_send_media_messages: true)
-    bot.param("permissions").should contain("can_send_photos")
+    legacy_permissions = TelegramBot::ChatPermissions.new(
+      can_send_audios: true,
+      can_send_documents: true,
+      can_send_photos: true,
+      can_send_videos: true,
+      can_send_video_notes: true,
+      can_send_voice_notes: true
+    )
+    params = bot.serialize_for_spec({"permissions" => legacy_permissions})
+    JSON.parse(params["permissions"].as(String)).should eq(JSON.parse(<<-JSON))
+      {
+        "can_send_audios": true,
+        "can_send_documents": true,
+        "can_send_photos": true,
+        "can_send_videos": true,
+        "can_send_video_notes": true,
+        "can_send_voice_notes": true
+      }
+      JSON
 
     invite = bot.create_chat_invite_link("@group", name: "Invite", creates_join_request: true)
 

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -890,6 +890,27 @@ module TelegramBot
       res.as_bool if res
     end
 
+    def set_message_reaction(chat_id : Int | String,
+                             message_id : Int,
+                             reaction : Array(ReactionType)? = nil,
+                             is_big : Bool? = nil)
+      res = def_request "setMessageReaction", chat_id, message_id, reaction, is_big
+      res.as_bool if res
+    end
+
+    def delete_message_reaction(chat_id : Int | String,
+                                message_id : Int,
+                                reaction : ReactionType)
+      res = def_request "deleteMessageReaction", chat_id, message_id, reaction
+      res.as_bool if res
+    end
+
+    def delete_all_message_reactions(chat_id : Int | String,
+                                     message_id : Int)
+      res = def_request "deleteAllMessageReactions", chat_id, message_id
+      res.as_bool if res
+    end
+
     def get_user_profile_photos(user_id : Int32,
                                 offset : Int32? = nil,
                                 limit : Int32? = nil)
@@ -916,8 +937,21 @@ module TelegramBot
                              can_send_messages : Bool? = nil,
                              can_send_media_messages : Bool? = nil,
                              can_send_other_messages : Bool? = nil,
-                             can_add_web_page_previews : Bool? = nil)
-      res = def_request "restrictChatMember", chat_id, user_id, until_date, can_send_messages, can_send_media_messages, can_send_other_messages, can_add_web_page_previews
+                             can_add_web_page_previews : Bool? = nil,
+                             permissions : ChatPermissions? = nil,
+                             use_independent_chat_permissions : Bool? = nil)
+      permissions ||= ChatPermissions.new(
+        can_send_messages: can_send_messages,
+        can_send_audios: can_send_media_messages,
+        can_send_documents: can_send_media_messages,
+        can_send_photos: can_send_media_messages,
+        can_send_videos: can_send_media_messages,
+        can_send_video_notes: can_send_media_messages,
+        can_send_voice_notes: can_send_media_messages,
+        can_send_other_messages: can_send_other_messages,
+        can_add_web_page_previews: can_add_web_page_previews
+      )
+      res = def_request "restrictChatMember", chat_id, user_id, permissions, use_independent_chat_permissions, until_date
       res.as_bool if res
     end
 
@@ -938,6 +972,58 @@ module TelegramBot
     def export_chat_invite_link(chat_id : Int | String)
       res = def_request "exportChatInviteLink", chat_id
       res if res
+    end
+
+    def create_chat_invite_link(chat_id : Int | String,
+                                name : String? = nil,
+                                expire_date : Int? = nil,
+                                member_limit : Int32? = nil,
+                                creates_join_request : Bool? = nil) : ChatInviteLink?
+      res = def_request "createChatInviteLink", chat_id, name, expire_date, member_limit, creates_join_request
+      ChatInviteLink.from_json res.to_json if res
+    end
+
+    def edit_chat_invite_link(chat_id : Int | String,
+                              invite_link : String,
+                              name : String? = nil,
+                              expire_date : Int? = nil,
+                              member_limit : Int32? = nil,
+                              creates_join_request : Bool? = nil) : ChatInviteLink?
+      res = def_request "editChatInviteLink", chat_id, invite_link, name, expire_date, member_limit, creates_join_request
+      ChatInviteLink.from_json res.to_json if res
+    end
+
+    def create_chat_subscription_invite_link(chat_id : Int | String,
+                                             subscription_period : Int,
+                                             subscription_price : Int,
+                                             name : String? = nil) : ChatInviteLink?
+      res = def_request "createChatSubscriptionInviteLink", chat_id, name, subscription_period, subscription_price
+      ChatInviteLink.from_json res.to_json if res
+    end
+
+    def edit_chat_subscription_invite_link(chat_id : Int | String,
+                                           invite_link : String,
+                                           name : String? = nil) : ChatInviteLink?
+      res = def_request "editChatSubscriptionInviteLink", chat_id, invite_link, name
+      ChatInviteLink.from_json res.to_json if res
+    end
+
+    def revoke_chat_invite_link(chat_id : Int | String,
+                                invite_link : String) : ChatInviteLink?
+      res = def_request "revokeChatInviteLink", chat_id, invite_link
+      ChatInviteLink.from_json res.to_json if res
+    end
+
+    def approve_chat_join_request(chat_id : Int | String,
+                                  user_id : Int)
+      res = def_request "approveChatJoinRequest", chat_id, user_id
+      res.as_bool if res
+    end
+
+    def decline_chat_join_request(chat_id : Int | String,
+                                  user_id : Int)
+      res = def_request "declineChatJoinRequest", chat_id, user_id
+      res.as_bool if res
     end
 
     def set_chat_photo(chat_id : Int | String, photo : ::File)
@@ -1006,6 +1092,85 @@ module TelegramBot
 
     def delete_chat_sticker_set(chat_id : Int | String)
       res = def_request "deleteChatStickerSet", chat_id
+      res.as_bool if res
+    end
+
+    def get_forum_topic_icon_stickers : Array(Sticker)
+      res = request "getForumTopicIconStickers", force_http: true
+      res = res.not_nil!.as_a
+      stickers = Array(Sticker).new
+      res.each { |sticker| stickers << Sticker.from_json(sticker.to_json) }
+      stickers
+    end
+
+    def create_forum_topic(chat_id : Int | String,
+                           name : String,
+                           icon_color : Int32? = nil,
+                           icon_custom_emoji_id : String? = nil) : ForumTopic?
+      res = def_request "createForumTopic", chat_id, name, icon_color, icon_custom_emoji_id
+      ForumTopic.from_json res.to_json if res
+    end
+
+    def edit_forum_topic(chat_id : Int | String,
+                         message_thread_id : Int,
+                         name : String? = nil,
+                         icon_custom_emoji_id : String? = nil)
+      res = def_request "editForumTopic", chat_id, message_thread_id, name, icon_custom_emoji_id
+      res.as_bool if res
+    end
+
+    def close_forum_topic(chat_id : Int | String,
+                          message_thread_id : Int)
+      res = def_request "closeForumTopic", chat_id, message_thread_id
+      res.as_bool if res
+    end
+
+    def reopen_forum_topic(chat_id : Int | String,
+                           message_thread_id : Int)
+      res = def_request "reopenForumTopic", chat_id, message_thread_id
+      res.as_bool if res
+    end
+
+    def delete_forum_topic(chat_id : Int | String,
+                           message_thread_id : Int)
+      res = def_request "deleteForumTopic", chat_id, message_thread_id
+      res.as_bool if res
+    end
+
+    def unpin_all_forum_topic_messages(chat_id : Int | String,
+                                       message_thread_id : Int)
+      res = def_request "unpinAllForumTopicMessages", chat_id, message_thread_id
+      res.as_bool if res
+    end
+
+    def edit_general_forum_topic(chat_id : Int | String,
+                                 name : String)
+      res = def_request "editGeneralForumTopic", chat_id, name
+      res.as_bool if res
+    end
+
+    def close_general_forum_topic(chat_id : Int | String)
+      res = def_request "closeGeneralForumTopic", chat_id
+      res.as_bool if res
+    end
+
+    def reopen_general_forum_topic(chat_id : Int | String)
+      res = def_request "reopenGeneralForumTopic", chat_id
+      res.as_bool if res
+    end
+
+    def hide_general_forum_topic(chat_id : Int | String)
+      res = def_request "hideGeneralForumTopic", chat_id
+      res.as_bool if res
+    end
+
+    def unhide_general_forum_topic(chat_id : Int | String)
+      res = def_request "unhideGeneralForumTopic", chat_id
+      res.as_bool if res
+    end
+
+    def unpin_all_general_forum_topic_messages(chat_id : Int | String)
+      res = def_request "unpinAllGeneralForumTopicMessages", chat_id
       res.as_bool if res
     end
 

--- a/src/telegram_bot/types/chat_invite_link.cr
+++ b/src/telegram_bot/types/chat_invite_link.cr
@@ -1,0 +1,17 @@
+module TelegramBot
+  class ChatInviteLink
+    include JSON::Serializable
+
+    property invite_link : String
+    property creator : User
+    property? creates_join_request : Bool
+    property? is_primary : Bool
+    property? is_revoked : Bool
+    property name : String?
+    property expire_date : Int32?
+    property member_limit : Int32?
+    property pending_join_request_count : Int32?
+    property subscription_period : Int32?
+    property subscription_price : Int32?
+  end
+end

--- a/src/telegram_bot/types/chat_join_request.cr
+++ b/src/telegram_bot/types/chat_join_request.cr
@@ -7,6 +7,6 @@ module TelegramBot
     property user_chat_id : Int64?
     property date : Int32?
     property bio : String?
-    property invite_link : JSON::Any?
+    property invite_link : ChatInviteLink?
   end
 end

--- a/src/telegram_bot/types/chat_member.cr
+++ b/src/telegram_bot/types/chat_member.cr
@@ -5,18 +5,39 @@ module TelegramBot
     property user : User
     property status : String
     property until_date : Int64?
+    property? is_anonymous : Bool?
+    property custom_title : String?
     property? can_be_edited : Bool?
     property? can_change_info : Bool?
     property? can_post_messages : Bool?
     property? can_edit_messages : Bool?
     property? can_delete_messages : Bool?
+    property? can_manage_chat : Bool?
+    property? can_manage_video_chats : Bool?
     property? can_invite_users : Bool?
     property? can_restrict_members : Bool?
     property? can_pin_messages : Bool?
     property? can_promote_members : Bool?
+    property? can_manage_topics : Bool?
+    property? can_manage_direct_messages : Bool?
+    property? can_post_stories : Bool?
+    property? can_edit_stories : Bool?
+    property? can_delete_stories : Bool?
+    property? can_manage_tags : Bool?
+    property? can_edit_tag : Bool?
+    property tag : String?
     property? can_send_messages : Bool?
+    property? can_send_audios : Bool?
+    property? can_send_documents : Bool?
+    property? can_send_photos : Bool?
+    property? can_send_videos : Bool?
+    property? can_send_video_notes : Bool?
+    property? can_send_voice_notes : Bool?
+    property? can_send_polls : Bool?
     property? can_send_media_messages : Bool?
     property? can_send_other_messages : Bool?
     property? can_add_web_page_previews : Bool?
+    property? can_react_to_messages : Bool?
+    property? is_member : Bool?
   end
 end

--- a/src/telegram_bot/types/chat_member_updated.cr
+++ b/src/telegram_bot/types/chat_member_updated.cr
@@ -7,7 +7,7 @@ module TelegramBot
     property date : Int32?
     property old_chat_member : ChatMember?
     property new_chat_member : ChatMember?
-    property invite_link : JSON::Any?
+    property invite_link : ChatInviteLink?
     property? via_join_request : Bool?
     property? via_chat_folder_invite_link : Bool?
   end

--- a/src/telegram_bot/types/chat_permissions.cr
+++ b/src/telegram_bot/types/chat_permissions.cr
@@ -1,0 +1,41 @@
+module TelegramBot
+  class ChatPermissions
+    include JSON::Serializable
+
+    property? can_send_messages : Bool?
+    property? can_send_audios : Bool?
+    property? can_send_documents : Bool?
+    property? can_send_photos : Bool?
+    property? can_send_videos : Bool?
+    property? can_send_video_notes : Bool?
+    property? can_send_voice_notes : Bool?
+    property? can_send_polls : Bool?
+    property? can_send_other_messages : Bool?
+    property? can_add_web_page_previews : Bool?
+    property? can_change_info : Bool?
+    property? can_invite_users : Bool?
+    property? can_pin_messages : Bool?
+    property? can_manage_topics : Bool?
+    property? can_react_to_messages : Bool?
+
+    def initialize(
+      *,
+      @can_send_messages = nil,
+      @can_send_audios = nil,
+      @can_send_documents = nil,
+      @can_send_photos = nil,
+      @can_send_videos = nil,
+      @can_send_video_notes = nil,
+      @can_send_voice_notes = nil,
+      @can_send_polls = nil,
+      @can_send_other_messages = nil,
+      @can_add_web_page_previews = nil,
+      @can_change_info = nil,
+      @can_invite_users = nil,
+      @can_pin_messages = nil,
+      @can_manage_topics = nil,
+      @can_react_to_messages = nil,
+    )
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add `ChatPermissions` and `ChatInviteLink`
- Expand `ChatMember` to parse modern owner, administrator, member, restricted, left, and banned member payload fields
- Type `invite_link` on `ChatMemberUpdated` and `ChatJoinRequest`
- Add invite link methods:
  - `create_chat_invite_link`
  - `edit_chat_invite_link`
  - `create_chat_subscription_invite_link`
  - `edit_chat_subscription_invite_link`
  - `revoke_chat_invite_link`
- Add join request methods:
  - `approve_chat_join_request`
  - `decline_chat_join_request`
- Add forum topic methods:
  - `get_forum_topic_icon_stickers`
  - `create_forum_topic`
  - `edit_forum_topic`
  - `close_forum_topic`
  - `reopen_forum_topic`
  - `delete_forum_topic`
  - `unpin_all_forum_topic_messages`
  - `edit_general_forum_topic`
  - `close_general_forum_topic`
  - `reopen_general_forum_topic`
  - `hide_general_forum_topic`
  - `unhide_general_forum_topic`
  - `unpin_all_general_forum_topic_messages`
- Add reaction methods:
  - `set_message_reaction`
  - `delete_message_reaction`
  - `delete_all_message_reactions`