### PR TITLE
Add Stars and paid media support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ api methods and types:
 - [x] webhook metadata and command scopes
 - [x] bot profile and default administrator-rights methods
 - [x] invite link, join request, forum topic, and reaction methods
-- [ ] Stars, gifts, and paid media methods
+- [x] Stars and paid media methods
+- [ ] gifts
 - [ ] full business, guest, and managed bot APIs
 
 getting updates:
@@ -314,8 +315,10 @@ types, while unimplemented items are intentionally left out of the public API.
   `hide_general_forum_topic`, `unhide_general_forum_topic`,
   `unpin_all_general_forum_topic_messages`, `set_message_reaction`,
   `delete_message_reaction`, `delete_all_message_reactions`
-- Payments and stickers: `send_invoice`, `answer_shipping_query`,
-  `answer_pre_checkout_query`, `get_sticker_set`, `upload_sticker_file`,
+- Payments, Stars, paid media, and stickers: `send_invoice`,
+  `send_paid_media`, `answer_shipping_query`, `answer_pre_checkout_query`,
+  `get_my_star_balance`, `get_star_transactions`, `refund_star_payment`,
+  `edit_user_star_subscription`, `get_sticker_set`, `upload_sticker_file`,
   `create_new_sticker_set`, `add_sticker_to_set`,
   `set_sticker_position_in_set`, `delete_sticker_position_in_set`
 - Bot commands and profile: `set_my_commands`, `get_my_commands`,
@@ -371,6 +374,12 @@ Override these methods in your bot subclass:
   `GeneralForumTopicUnhidden`
 - Chat administration: `ChatPermissions`, `ChatMember`,
   `ChatMemberUpdated`, `ChatInviteLink`, `ChatJoinRequest`
+- Stars and paid media: `LivePhoto`, `PaidMediaInfo`, `PaidMedia`,
+  `PaidMediaPreview`, `PaidMediaPhoto`, `PaidMediaVideo`,
+  `PaidMediaLivePhoto`, `InputPaidMediaPhoto`, `InputPaidMediaVideo`,
+  `InputPaidMediaLivePhoto`, `RefundedPayment`, `StarAmount`,
+  `RevenueWithdrawalState`, `AffiliateInfo`, `TransactionPartner`,
+  `StarTransaction`, `StarTransactions`
 - Keyboards and Web Apps: `InlineKeyboardButton`, `InlineKeyboardMarkup`,
   `KeyboardButton`, `ReplyKeyboardMarkup`, `LoginUrl`, `WebAppInfo`,
   `WebAppData`, `SwitchInlineQueryChosenChat`, `CopyTextButton`,
@@ -394,7 +403,7 @@ Override these methods in your bot subclass:
 - Profile photo and chat menu button methods
 - Newer chat administration APIs outside Phase 7, such as `set_chat_member_tag`
   and user profile audio methods
-- Stars, gifts, paid media methods, and their full type graph
+- Gift types and methods
 - Full business, guest, and managed bot method/type support
 
 ## Compatibility notes

--- a/TODO.md
+++ b/TODO.md
@@ -270,27 +270,27 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 9: Payments, Stars, Gifts, Paid Media
 
-- [ ] Add modern payment fields:
-  - [ ] `RefundedPayment`
-  - [ ] `RevenueWithdrawalState`
-  - [ ] `TransactionPartner`
-  - [ ] `StarTransaction`
-  - [ ] `StarTransactions`
-  - [ ] `StarAmount`
-- [ ] Add paid media types:
-  - [ ] `PaidMediaInfo`
-  - [ ] `PaidMediaPreview`
-  - [ ] `PaidMediaPhoto`
-  - [ ] `PaidMediaVideo`
-  - [ ] `PaidMediaLivePhoto`
-  - [ ] `InputPaidMediaPhoto`
-  - [ ] `InputPaidMediaVideo`
-  - [ ] `InputPaidMediaLivePhoto`
-- [ ] Add paid media methods:
-  - [ ] `send_paid_media`
-  - [ ] `get_star_transactions`
-  - [ ] `refund_star_payment`
-  - [ ] `edit_user_star_subscription`
+- [x] Add modern payment fields:
+  - [x] `RefundedPayment`
+  - [x] `RevenueWithdrawalState`
+  - [x] `TransactionPartner`
+  - [x] `StarTransaction`
+  - [x] `StarTransactions`
+  - [x] `StarAmount`
+- [x] Add paid media types:
+  - [x] `PaidMediaInfo`
+  - [x] `PaidMediaPreview`
+  - [x] `PaidMediaPhoto`
+  - [x] `PaidMediaVideo`
+  - [x] `PaidMediaLivePhoto`
+  - [x] `InputPaidMediaPhoto`
+  - [x] `InputPaidMediaVideo`
+  - [x] `InputPaidMediaLivePhoto`
+- [x] Add paid media methods:
+  - [x] `send_paid_media`
+  - [x] `get_star_transactions`
+  - [x] `refund_star_payment`
+  - [x] `edit_user_star_subscription`
 - [ ] Add gift types and methods if needed by downstream users.
 
 ## Phase 10: Business, Guest, And Managed Bot Support

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -194,3 +194,81 @@ describe TelegramBot::ChatMember do
     update.invite_link.try(&.invite_link).should eq("https://t.me/+invite")
   end
 end
+
+describe TelegramBot::PaidMediaInfo do
+  it "parses paid media, live photos, and refunded payments" do
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "live_photo": {
+          "file_id": "live-video-id",
+          "file_unique_id": "live-video-unique-id",
+          "width": 320,
+          "height": 240,
+          "duration": 3,
+          "photo": [
+            {"file_id": "photo-id", "file_unique_id": "photo-unique-id", "width": 320, "height": 240}
+          ]
+        },
+        "paid_media": {
+          "star_count": 10,
+          "paid_media": [
+            {"type": "preview", "width": 320, "height": 240, "duration": 3},
+            {
+              "type": "photo",
+              "photo": [
+                {"file_id": "photo-id", "file_unique_id": "photo-unique-id", "width": 320, "height": 240}
+              ]
+            }
+          ]
+        },
+        "successful_payment": {
+          "currency": "XTR",
+          "total_amount": 10,
+          "invoice_payload": "invoice-payload",
+          "subscription_expiration_date": 1800000000,
+          "is_recurring": true,
+          "is_first_recurring": true,
+          "telegram_payment_charge_id": "telegram-charge-id",
+          "provider_payment_charge_id": "provider-charge-id"
+        },
+        "refunded_payment": {
+          "currency": "XTR",
+          "total_amount": 10,
+          "invoice_payload": "invoice-payload",
+          "telegram_payment_charge_id": "telegram-charge-id"
+        }
+      }
+      JSON
+    transactions = TelegramBot::StarTransactions.from_json(<<-JSON)
+      {
+        "transactions": [
+          {
+            "id": "tx-id",
+            "amount": 10,
+            "date": 1800000000,
+            "source": {
+              "type": "user",
+              "transaction_type": "paid_media_payment",
+              "user": {"id": 1, "is_bot": false, "first_name": "User"},
+              "paid_media_payload": "payload",
+              "paid_media": [{"type": "preview", "width": 320}]
+            }
+          }
+        ]
+      }
+      JSON
+
+    message.live_photo.try(&.file_id).should eq("live-video-id")
+    message.paid_media.try(&.star_count).should eq(10)
+    message.paid_media.try(&.paid_media.first.type).should eq("preview")
+    message.paid_media.try(&.paid_media.last.photo.try(&.first.file_id)).should eq("photo-id")
+    message.successful_payment.try(&.subscription_expiration_date).should eq(1_800_000_000)
+    message.successful_payment.try(&.is_recurring?).should be_true
+    message.refunded_payment.try(&.telegram_payment_charge_id).should eq("telegram-charge-id")
+    transactions.transactions.first.source.try(&.paid_media_payload).should eq("payload")
+    transactions.transactions.first.source.try(&.paid_media.try(&.first.type)).should eq("preview")
+  end
+end

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -23,6 +23,8 @@ class RequestBuildingBot < TelegramBot::Bot
     "setMessageReaction",
     "deleteMessageReaction",
     "deleteAllMessageReactions",
+    "refundStarPayment",
+    "editUserStarSubscription",
     "editForumTopic",
     "closeForumTopic",
     "reopenForumTopic",
@@ -56,6 +58,9 @@ class RequestBuildingBot < TelegramBot::Bot
     "revokeChatInviteLink"             => %({"invite_link":"https://t.me/+invite","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":true}),
     "getForumTopicIconStickers"        => %([{"file_id":"sticker-id","width":512,"height":512}]),
     "createForumTopic"                 => %({"message_thread_id":42,"name":"Topic","icon_color":7322096,"icon_custom_emoji_id":"emoji-id"}),
+    "sendPaidMedia"                    => %({"message_id":1,"date":0,"chat":{"id":1,"type":"private"},"paid_media":{"star_count":10,"paid_media":[{"type":"preview","width":320,"height":240}]}}),
+    "getMyStarBalance"                 => %({"amount":100,"nanostar_amount":500}),
+    "getStarTransactions"              => %({"transactions":[{"id":"tx-id","amount":10,"date":1800000000,"source":{"type":"user","transaction_type":"paid_media_payment","user":{"id":1,"is_bot":false,"first_name":"User"},"paid_media_payload":"payload","paid_media":[{"type":"preview","width":320}]}}]}),
   }
 
   def initialize
@@ -280,6 +285,70 @@ describe TelegramBot::Bot do
     bot.last_method.should eq("sendDice")
     bot.last_params["emoji"].should eq("🎲")
     bot.last_params["protect_content"].should eq("true")
+  end
+
+  it "builds sendPaidMedia and Star payment methods" do
+    bot = RequestBuildingBot.new
+    media = [
+      TelegramBot::InputPaidMediaPhoto.new("photo-id"),
+      TelegramBot::InputPaidMediaVideo.new("video-id", thumbnail: "thumb-id", supports_streaming: true),
+    ] of TelegramBot::InputPaidMedia
+
+    message = bot.send_paid_media(
+      123,
+      10,
+      media,
+      payload: "payload",
+      caption: "caption",
+      show_caption_above_media: true,
+      protect_content: true
+    )
+
+    message.try(&.paid_media.try(&.star_count)).should eq(10)
+    bot.last_method.should eq("sendPaidMedia")
+    bot.last_params["star_count"].should eq("10")
+    bot.param("media").should contain("InputPaidMediaPhoto")
+    bot.last_params["payload"].should eq("payload")
+    bot.last_params["show_caption_above_media"].should eq("true")
+
+    params = bot.serialize_for_spec({"media" => media})
+    JSON.parse(params["media"].as(String)).should eq(JSON.parse(<<-JSON))
+      [
+        {"type": "photo", "media": "photo-id"},
+        {
+          "type": "video",
+          "media": "video-id",
+          "thumbnail": "thumb-id",
+          "supports_streaming": true
+        }
+      ]
+      JSON
+
+    balance = bot.get_my_star_balance
+
+    balance.amount.should eq(100)
+    balance.nanostar_amount.should eq(500)
+    bot.last_method.should eq("getMyStarBalance")
+    bot.last_force_http.should be_true
+
+    transactions = bot.get_star_transactions(offset: 1, limit: 10)
+
+    transactions.transactions.first.id.should eq("tx-id")
+    transactions.transactions.first.source.try(&.paid_media_payload).should eq("payload")
+    bot.last_method.should eq("getStarTransactions")
+    bot.last_force_http.should be_true
+    bot.last_params["offset"].should eq("1")
+    bot.last_params["limit"].should eq("10")
+
+    bot.refund_star_payment(1, "charge-id").should be_true
+    bot.last_method.should eq("refundStarPayment")
+    bot.last_force_http.should be_true
+    bot.last_params["telegram_payment_charge_id"].should eq("charge-id")
+
+    bot.edit_user_star_subscription(1, "charge-id", true).should be_true
+    bot.last_method.should eq("editUserStarSubscription")
+    bot.last_force_http.should be_true
+    bot.last_params["is_canceled"].should eq("true")
   end
 
   it "builds sendMessageDraft" do

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -707,6 +707,27 @@ module TelegramBot
       Message.from_json res.to_json if res
     end
 
+    def send_paid_media(chat_id : Int | String,
+                        star_count : Int,
+                        media : Array(InputPaidMedia),
+                        business_connection_id : String? = nil,
+                        message_thread_id : Int32? = nil,
+                        direct_messages_topic_id : Int64? = nil,
+                        payload : String? = nil,
+                        caption : String? = nil,
+                        parse_mode : String? = nil,
+                        caption_entities : Array(MessageEntity)? = nil,
+                        show_caption_above_media : Bool? = nil,
+                        disable_notification : Bool? = nil,
+                        protect_content : Bool? = nil,
+                        allow_paid_broadcast : Bool? = nil,
+                        suggested_post_parameters : SuggestedPostParameters? = nil,
+                        reply_parameters : ReplyParameters? = nil,
+                        reply_markup : ReplyMarkup = nil) : Message?
+      res = def_request "sendPaidMedia", business_connection_id, chat_id, message_thread_id, direct_messages_topic_id, star_count, media, payload, caption, parse_mode, caption_entities, show_caption_above_media, disable_notification, protect_content, allow_paid_broadcast, suggested_post_parameters, reply_parameters, reply_markup
+      Message.from_json res.to_json if res
+    end
+
     def send_media_group(chat_id : Int | String,
                          media : Array(InputMedia),
                          disable_notification : Bool? = nil,
@@ -1405,6 +1426,30 @@ module TelegramBot
                                   ok : Bool,
                                   error_message : String? = nil) : Bool | Message?
       res = def_request "answerPreCheckoutQuery", pre_checkout_query_id, ok, error_message
+      res.as_bool if res
+    end
+
+    def get_my_star_balance : StarAmount
+      res = request "getMyStarBalance", force_http: true
+      StarAmount.from_json(res.to_json)
+    end
+
+    def get_star_transactions(offset : Int32? = nil,
+                              limit : Int32? = nil) : StarTransactions
+      res = def_force_request "getStarTransactions", offset, limit
+      StarTransactions.from_json(res.to_json)
+    end
+
+    def refund_star_payment(user_id : Int,
+                            telegram_payment_charge_id : String)
+      res = def_force_request "refundStarPayment", user_id, telegram_payment_charge_id
+      res.as_bool if res
+    end
+
+    def edit_user_star_subscription(user_id : Int,
+                                    telegram_payment_charge_id : String,
+                                    is_canceled : Bool)
+      res = def_force_request "editUserStarSubscription", user_id, telegram_payment_charge_id, is_canceled
       res.as_bool if res
     end
 

--- a/src/telegram_bot/types/external_reply_info.cr
+++ b/src/telegram_bot/types/external_reply_info.cr
@@ -9,8 +9,8 @@ module TelegramBot
     property animation : Animation?
     property audio : Audio?
     property document : Document?
-    property live_photo : JSON::Any?
-    property paid_media : JSON::Any?
+    property live_photo : LivePhoto?
+    property paid_media : PaidMediaInfo?
     property photo : Array(PhotoSize)?
     property sticker : Sticker?
     property story : JSON::Any?

--- a/src/telegram_bot/types/input_paid_media.cr
+++ b/src/telegram_bot/types/input_paid_media.cr
@@ -1,0 +1,71 @@
+module TelegramBot
+  abstract class InputPaidMedia
+    def to_json(json : JSON::Builder)
+      raise "InputPaidMedia subclasses must implement JSON serialization"
+    end
+  end
+
+  class InputPaidMediaPhoto < InputPaidMedia
+    include JSON::Serializable
+
+    property type : String = "photo"
+    property media : String
+
+    def initialize(@media : String)
+    end
+  end
+
+  class InputPaidMediaVideo < InputPaidMedia
+    include JSON::Serializable
+
+    property type : String = "video"
+    property media : String
+    property thumbnail : String?
+    property cover : String?
+    property start_timestamp : Int32?
+    property width : Int32?
+    property height : Int32?
+    property duration : Int32?
+    property? supports_streaming : Bool?
+
+    def initialize(
+      @media : String,
+      *,
+      @thumbnail : String? = nil,
+      @cover : String? = nil,
+      @start_timestamp : Int32? = nil,
+      @width : Int32? = nil,
+      @height : Int32? = nil,
+      @duration : Int32? = nil,
+      @supports_streaming = nil,
+    )
+    end
+  end
+
+  class InputPaidMediaLivePhoto < InputPaidMedia
+    include JSON::Serializable
+
+    property type : String = "live_photo"
+    property media : String
+    property thumbnail : String?
+    property cover : String?
+    property start_timestamp : Int32?
+    property width : Int32?
+    property height : Int32?
+    property duration : Int32?
+    property? supports_streaming : Bool?
+
+    def initialize(
+      @media : String,
+      *,
+      @thumbnail : String? = nil,
+      @cover : String? = nil,
+      @start_timestamp : Int32? = nil,
+      @width : Int32? = nil,
+      @height : Int32? = nil,
+      @duration : Int32? = nil,
+      @supports_streaming = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/live_photo.cr
+++ b/src/telegram_bot/types/live_photo.cr
@@ -1,0 +1,14 @@
+module TelegramBot
+  class LivePhoto
+    include JSON::Serializable
+
+    property photo : Array(PhotoSize)?
+    property file_id : String
+    property file_unique_id : String
+    property width : Int32
+    property height : Int32
+    property duration : Int32
+    property mime_type : String?
+    property file_size : Int64?
+  end
+end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -42,6 +42,8 @@ module TelegramBot
     property animation : Animation?
     property audio : Audio?
     property document : Document?
+    property live_photo : LivePhoto?
+    property paid_media : PaidMediaInfo?
     property photo : Array(PhotoSize)?
     property sticker : Sticker?
     property video : Video?
@@ -79,6 +81,7 @@ module TelegramBot
     property pinned_message : Message?
     property invoice : Invoice?
     property successful_payment : SuccessfulPayment?
+    property refunded_payment : RefundedPayment?
     property reply_markup : InlineKeyboardMarkup?
   end
 end

--- a/src/telegram_bot/types/paid_media.cr
+++ b/src/telegram_bot/types/paid_media.cr
@@ -1,0 +1,32 @@
+module TelegramBot
+  class PaidMediaInfo
+    include JSON::Serializable
+
+    property star_count : Int32
+    property paid_media : Array(PaidMedia)
+  end
+
+  class PaidMedia
+    include JSON::Serializable
+
+    property type : String
+    property live_photo : LivePhoto?
+    property photo : Array(PhotoSize)?
+    property video : Video?
+    property width : Int32?
+    property height : Int32?
+    property duration : Int32?
+  end
+
+  class PaidMediaPreview < PaidMedia
+  end
+
+  class PaidMediaPhoto < PaidMedia
+  end
+
+  class PaidMediaVideo < PaidMedia
+  end
+
+  class PaidMediaLivePhoto < PaidMedia
+  end
+end

--- a/src/telegram_bot/types/star_payment.cr
+++ b/src/telegram_bot/types/star_payment.cr
@@ -1,0 +1,73 @@
+module TelegramBot
+  class RefundedPayment
+    include JSON::Serializable
+
+    property currency : String
+    property total_amount : Int32
+    property invoice_payload : String
+    property telegram_payment_charge_id : String
+    property provider_payment_charge_id : String?
+  end
+
+  class StarAmount
+    include JSON::Serializable
+
+    property amount : Int32
+    property nanostar_amount : Int32?
+  end
+
+  class RevenueWithdrawalState
+    include JSON::Serializable
+
+    property type : String
+    property date : Int32?
+    property url : String?
+  end
+
+  class AffiliateInfo
+    include JSON::Serializable
+
+    property affiliate_user : User?
+    property affiliate_chat : Chat?
+    property commission_per_mille : Int32
+    property amount : Int32
+    property nanostar_amount : Int32?
+  end
+
+  class TransactionPartner
+    include JSON::Serializable
+
+    property type : String
+    property transaction_type : String?
+    property user : User?
+    property chat : Chat?
+    property affiliate : AffiliateInfo?
+    property invoice_payload : String?
+    property subscription_period : Int32?
+    property paid_media : Array(PaidMedia)?
+    property paid_media_payload : String?
+    property gift : JSON::Any?
+    property premium_subscription_duration : Int32?
+    property sponsor_user : User?
+    property commission_per_mille : Int32?
+    property withdrawal_state : RevenueWithdrawalState?
+    property request_count : Int32?
+  end
+
+  class StarTransaction
+    include JSON::Serializable
+
+    property id : String
+    property amount : Int32
+    property nanostar_amount : Int32?
+    property date : Int32
+    property source : TransactionPartner?
+    property receiver : TransactionPartner?
+  end
+
+  class StarTransactions
+    include JSON::Serializable
+
+    property transactions : Array(StarTransaction)
+  end
+end

--- a/src/telegram_bot/types/successful_payment.cr
+++ b/src/telegram_bot/types/successful_payment.cr
@@ -5,6 +5,9 @@ module TelegramBot
     property currency : String
     property total_amount : Int32
     property invoice_payload : String
+    property subscription_expiration_date : Int32?
+    property? is_recurring : Bool?
+    property? is_first_recurring : Bool?
     property shipping_option_id : String?
     property order_info : OrderInfo?
     property telegram_payment_charge_id : String


### PR DESCRIPTION
## Summary

- Add paid media response types:
  - `PaidMediaInfo`
  - `PaidMedia`
  - `PaidMediaPreview`
  - `PaidMediaPhoto`
  - `PaidMediaVideo`
  - `PaidMediaLivePhoto`
- Add input paid media types:
  - `InputPaidMediaPhoto`
  - `InputPaidMediaVideo`
  - `InputPaidMediaLivePhoto`
- Add Stars/payment types:
  - `RefundedPayment`
  - `StarAmount`
  - `RevenueWithdrawalState`
  - `AffiliateInfo`
  - `TransactionPartner`
  - `StarTransaction`
  - `StarTransactions`
- Add `LivePhoto`
- Parse `live_photo`, `paid_media`, and `refunded_payment` on messages
- Add recurring payment fields to `SuccessfulPayment`
- Add methods:
  - `send_paid_media`
  - `get_my_star_balance`
  - `get_star_transactions`
  - `refund_star_payment`
  - `edit_user_star_subscription`