### PR TITLE
Add gift support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ api methods and types:
 - [x] webhook metadata and command scopes
 - [x] bot profile and default administrator-rights methods
 - [x] invite link, join request, forum topic, and reaction methods
-- [x] Stars and paid media methods
-- [ ] gifts
+- [x] Stars, gifts, and paid media methods
 - [ ] full business, guest, and managed bot APIs
 
 getting updates:
@@ -315,10 +314,11 @@ types, while unimplemented items are intentionally left out of the public API.
   `hide_general_forum_topic`, `unhide_general_forum_topic`,
   `unpin_all_general_forum_topic_messages`, `set_message_reaction`,
   `delete_message_reaction`, `delete_all_message_reactions`
-- Payments, Stars, paid media, and stickers: `send_invoice`,
+- Payments, Stars, gifts, paid media, and stickers: `send_invoice`,
   `send_paid_media`, `answer_shipping_query`, `answer_pre_checkout_query`,
   `get_my_star_balance`, `get_star_transactions`, `refund_star_payment`,
-  `edit_user_star_subscription`, `get_sticker_set`, `upload_sticker_file`,
+  `edit_user_star_subscription`, `get_available_gifts`, `send_gift`,
+  `gift_premium_subscription`, `get_sticker_set`, `upload_sticker_file`,
   `create_new_sticker_set`, `add_sticker_to_set`,
   `set_sticker_position_in_set`, `delete_sticker_position_in_set`
 - Bot commands and profile: `set_my_commands`, `get_my_commands`,
@@ -380,6 +380,10 @@ Override these methods in your bot subclass:
   `InputPaidMediaLivePhoto`, `RefundedPayment`, `StarAmount`,
   `RevenueWithdrawalState`, `AffiliateInfo`, `TransactionPartner`,
   `StarTransaction`, `StarTransactions`
+- Gifts: `Gift`, `Gifts`, `GiftInfo`, `GiftBackground`, `UniqueGift`,
+  `UniqueGiftInfo`, `UniqueGiftModel`, `UniqueGiftSymbol`,
+  `UniqueGiftBackdrop`, `UniqueGiftBackdropColors`, `UniqueGiftColors`,
+  `OwnedGift`, `OwnedGifts`
 - Keyboards and Web Apps: `InlineKeyboardButton`, `InlineKeyboardMarkup`,
   `KeyboardButton`, `ReplyKeyboardMarkup`, `LoginUrl`, `WebAppInfo`,
   `WebAppData`, `SwitchInlineQueryChosenChat`, `CopyTextButton`,
@@ -403,7 +407,7 @@ Override these methods in your bot subclass:
 - Profile photo and chat menu button methods
 - Newer chat administration APIs outside Phase 7, such as `set_chat_member_tag`
   and user profile audio methods
-- Gift types and methods
+- Business-account owned gift management methods
 - Full business, guest, and managed bot method/type support
 
 ## Compatibility notes

--- a/TODO.md
+++ b/TODO.md
@@ -291,7 +291,7 @@ keeping backward-compatible method signatures where practical.
   - [x] `get_star_transactions`
   - [x] `refund_star_payment`
   - [x] `edit_user_star_subscription`
-- [ ] Add gift types and methods if needed by downstream users.
+- [x] Add gift types and methods if needed by downstream users.
 
 ## Phase 10: Business, Guest, And Managed Bot Support
 

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -272,3 +272,98 @@ describe TelegramBot::PaidMediaInfo do
     transactions.transactions.first.source.try(&.paid_media.try(&.first.type)).should eq("preview")
   end
 end
+
+describe TelegramBot::Gift do
+  it "parses gifts and gift message fields" do
+    gifts = TelegramBot::Gifts.from_json(<<-JSON)
+      {
+        "gifts": [
+          {
+            "id": "gift-id",
+            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "star_count": 100,
+            "upgrade_star_count": 25,
+            "background": {
+              "center_color": 16777215,
+              "edge_color": 0,
+              "text_color": 255
+            }
+          }
+        ]
+      }
+      JSON
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "gift": {
+          "gift": {
+            "id": "gift-id",
+            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "star_count": 100
+          },
+          "owned_gift_id": "owned-gift-id",
+          "can_be_upgraded": true,
+          "text": "Thanks"
+        },
+        "unique_gift": {
+          "origin": "upgrade",
+          "gift": {
+            "gift_id": "gift-id",
+            "base_name": "Gift",
+            "name": "Gift #1",
+            "number": 1,
+            "model": {
+              "name": "Model",
+              "sticker": {"file_id": "model-sticker-id", "width": 512, "height": 512},
+              "rarity_per_mille": 100
+            },
+            "symbol": {
+              "name": "Symbol",
+              "sticker": {"file_id": "symbol-sticker-id", "width": 512, "height": 512},
+              "rarity_per_mille": 100
+            },
+            "backdrop": {
+              "name": "Backdrop",
+              "colors": {
+                "center_color": 1,
+                "edge_color": 2,
+                "symbol_color": 3,
+                "text_color": 4
+              },
+              "rarity_per_mille": 100
+            }
+          }
+        },
+        "gift_upgrade_sent": {
+          "gift": {
+            "id": "gift-id",
+            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "star_count": 100
+          }
+        }
+      }
+      JSON
+    transaction = TelegramBot::TransactionPartner.from_json(<<-JSON)
+      {
+        "type": "user",
+        "transaction_type": "gift_purchase",
+        "user": {"id": 1, "is_bot": false, "first_name": "User"},
+        "gift": {
+          "id": "gift-id",
+          "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+          "star_count": 100
+        }
+      }
+      JSON
+
+    gifts.gifts.first.id.should eq("gift-id")
+    gifts.gifts.first.background.try(&.text_color).should eq(255)
+    message.gift.try(&.owned_gift_id).should eq("owned-gift-id")
+    message.gift.try(&.can_be_upgraded?).should be_true
+    message.unique_gift.try(&.gift.name).should eq("Gift #1")
+    message.gift_upgrade_sent.try(&.gift.id).should eq("gift-id")
+    transaction.gift.try(&.star_count).should eq(100)
+  end
+end

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -25,6 +25,8 @@ class RequestBuildingBot < TelegramBot::Bot
     "deleteAllMessageReactions",
     "refundStarPayment",
     "editUserStarSubscription",
+    "sendGift",
+    "giftPremiumSubscription",
     "editForumTopic",
     "closeForumTopic",
     "reopenForumTopic",
@@ -61,6 +63,7 @@ class RequestBuildingBot < TelegramBot::Bot
     "sendPaidMedia"                    => %({"message_id":1,"date":0,"chat":{"id":1,"type":"private"},"paid_media":{"star_count":10,"paid_media":[{"type":"preview","width":320,"height":240}]}}),
     "getMyStarBalance"                 => %({"amount":100,"nanostar_amount":500}),
     "getStarTransactions"              => %({"transactions":[{"id":"tx-id","amount":10,"date":1800000000,"source":{"type":"user","transaction_type":"paid_media_payment","user":{"id":1,"is_bot":false,"first_name":"User"},"paid_media_payload":"payload","paid_media":[{"type":"preview","width":320}]}}]}),
+    "getAvailableGifts"                => %({"gifts":[{"id":"gift-id","sticker":{"file_id":"sticker-id","width":512,"height":512},"star_count":100,"upgrade_star_count":25}]}),
   }
 
   def initialize
@@ -349,6 +352,30 @@ describe TelegramBot::Bot do
     bot.last_method.should eq("editUserStarSubscription")
     bot.last_force_http.should be_true
     bot.last_params["is_canceled"].should eq("true")
+
+    gifts = bot.get_available_gifts
+
+    gifts.gifts.first.id.should eq("gift-id")
+    gifts.gifts.first.star_count.should eq(100)
+    bot.last_method.should eq("getAvailableGifts")
+    bot.last_force_http.should be_true
+
+    entities = [TelegramBot::MessageEntity.new("bold", 0, 4)]
+    bot.send_gift("gift-id", user_id: 1, pay_for_upgrade: true, text: "gift", text_entities: entities).should be_true
+
+    bot.last_method.should eq("sendGift")
+    bot.last_force_http.should be_true
+    bot.last_params["gift_id"].should eq("gift-id")
+    bot.last_params["user_id"].should eq("1")
+    bot.last_params["pay_for_upgrade"].should eq("true")
+    bot.param("text_entities").should contain("MessageEntity")
+
+    bot.gift_premium_subscription(1, 3, 1000, text: "premium").should be_true
+
+    bot.last_method.should eq("giftPremiumSubscription")
+    bot.last_force_http.should be_true
+    bot.last_params["month_count"].should eq("3")
+    bot.last_params["star_count"].should eq("1000")
   end
 
   it "builds sendMessageDraft" do

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -1344,6 +1344,32 @@ module TelegramBot
       WebhookInfo.from_json(res.to_json)
     end
 
+    def get_available_gifts : Gifts
+      res = request "getAvailableGifts", force_http: true
+      Gifts.from_json(res.to_json)
+    end
+
+    def send_gift(gift_id : String,
+                  user_id : Int? = nil,
+                  chat_id : Int | String? = nil,
+                  pay_for_upgrade : Bool? = nil,
+                  text : String? = nil,
+                  text_parse_mode : String? = nil,
+                  text_entities : Array(MessageEntity)? = nil)
+      res = def_force_request "sendGift", user_id, chat_id, gift_id, pay_for_upgrade, text, text_parse_mode, text_entities
+      res.as_bool if res
+    end
+
+    def gift_premium_subscription(user_id : Int,
+                                  month_count : Int,
+                                  star_count : Int,
+                                  text : String? = nil,
+                                  text_parse_mode : String? = nil,
+                                  text_entities : Array(MessageEntity)? = nil)
+      res = def_force_request "giftPremiumSubscription", user_id, month_count, star_count, text, text_parse_mode, text_entities
+      res.as_bool if res
+    end
+
     #
     # Games
     #

--- a/src/telegram_bot/types/gift.cr
+++ b/src/telegram_bot/types/gift.cr
@@ -1,0 +1,154 @@
+module TelegramBot
+  class GiftBackground
+    include JSON::Serializable
+
+    property center_color : Int32
+    property edge_color : Int32
+    property text_color : Int32
+  end
+
+  class Gift
+    include JSON::Serializable
+
+    property id : String
+    property sticker : Sticker
+    property star_count : Int32
+    property upgrade_star_count : Int32?
+    property? is_premium : Bool?
+    property? has_colors : Bool?
+    property total_count : Int32?
+    property remaining_count : Int32?
+    property personal_total_count : Int32?
+    property personal_remaining_count : Int32?
+    property background : GiftBackground?
+    property unique_gift_variant_count : Int32?
+    property publisher_chat : Chat?
+  end
+
+  class Gifts
+    include JSON::Serializable
+
+    property gifts : Array(Gift)
+  end
+
+  class UniqueGiftModel
+    include JSON::Serializable
+
+    property name : String
+    property sticker : Sticker
+    property rarity_per_mille : Int32
+    property rarity : String?
+  end
+
+  class UniqueGiftSymbol
+    include JSON::Serializable
+
+    property name : String
+    property sticker : Sticker
+    property rarity_per_mille : Int32
+  end
+
+  class UniqueGiftBackdropColors
+    include JSON::Serializable
+
+    property center_color : Int32
+    property edge_color : Int32
+    property symbol_color : Int32
+    property text_color : Int32
+  end
+
+  class UniqueGiftBackdrop
+    include JSON::Serializable
+
+    property name : String
+    property colors : UniqueGiftBackdropColors
+    property rarity_per_mille : Int32
+  end
+
+  class UniqueGiftColors
+    include JSON::Serializable
+
+    property model_custom_emoji_id : String
+    property symbol_custom_emoji_id : String
+    property light_theme_main_color : Int32
+    property light_theme_other_colors : Array(Int32)
+    property dark_theme_main_color : Int32
+    property dark_theme_other_colors : Array(Int32)
+  end
+
+  class UniqueGift
+    include JSON::Serializable
+
+    property gift_id : String
+    property base_name : String
+    property name : String
+    property number : Int32
+    property model : UniqueGiftModel
+    property symbol : UniqueGiftSymbol
+    property backdrop : UniqueGiftBackdrop
+    property? is_premium : Bool?
+    property? is_burned : Bool?
+    property? is_from_blockchain : Bool?
+    property colors : UniqueGiftColors?
+    property publisher_chat : Chat?
+  end
+
+  class GiftInfo
+    include JSON::Serializable
+
+    property gift : Gift
+    property owned_gift_id : String?
+    property convert_star_count : Int32?
+    property prepaid_upgrade_star_count : Int32?
+    property? is_upgrade_separate : Bool?
+    property? can_be_upgraded : Bool?
+    property text : String?
+    property entities : Array(MessageEntity)?
+    property? is_private : Bool?
+    property unique_gift_number : Int32?
+  end
+
+  class UniqueGiftInfo
+    include JSON::Serializable
+
+    property gift : UniqueGift
+    property origin : String
+    property last_resale_currency : String?
+    property last_resale_amount : Int32?
+    property owned_gift_id : String?
+    property transfer_star_count : Int32?
+    property next_transfer_date : Int32?
+  end
+
+  class OwnedGift
+    include JSON::Serializable
+
+    property type : String
+    property gift : Gift?
+    property unique_gift : UniqueGift?
+    property owned_gift_id : String?
+    property sender_user : User?
+    property send_date : Int32?
+    property text : String?
+    property entities : Array(MessageEntity)?
+    property? is_private : Bool?
+    property? is_saved : Bool?
+    property? can_be_upgraded : Bool?
+    property? was_refunded : Bool?
+    property convert_star_count : Int32?
+    property prepaid_upgrade_star_count : Int32?
+    property? is_upgrade_separate : Bool?
+    property unique_gift_number : Int32?
+    property? can_be_transferred : Bool?
+    property transfer_star_count : Int32?
+    property next_transfer_date : Int32?
+  end
+
+  class OwnedGifts
+    include JSON::Serializable
+
+    property total_count : Int32
+    property gifts : Array(OwnedGift)
+    property next_offset : String?
+  end
+end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -82,6 +82,9 @@ module TelegramBot
     property invoice : Invoice?
     property successful_payment : SuccessfulPayment?
     property refunded_payment : RefundedPayment?
+    property gift : GiftInfo?
+    property unique_gift : UniqueGiftInfo?
+    property gift_upgrade_sent : GiftInfo?
     property reply_markup : InlineKeyboardMarkup?
   end
 end

--- a/src/telegram_bot/types/star_payment.cr
+++ b/src/telegram_bot/types/star_payment.cr
@@ -46,7 +46,7 @@ module TelegramBot
     property subscription_period : Int32?
     property paid_media : Array(PaidMedia)?
     property paid_media_payload : String?
-    property gift : JSON::Any?
+    property gift : Gift?
     property premium_subscription_duration : Int32?
     property sponsor_user : User?
     property commission_per_mille : Int32?


### PR DESCRIPTION
## Summary

- Add gift catalog and message types:
  - `Gift`
  - `Gifts`
  - `GiftInfo`
  - `GiftBackground`
- Add unique gift types:
  - `UniqueGift`
  - `UniqueGiftInfo`
  - `UniqueGiftModel`
  - `UniqueGiftSymbol`
  - `UniqueGiftBackdrop`
  - `UniqueGiftBackdropColors`
  - `UniqueGiftColors`
- Add owned gift containers:
  - `OwnedGift`
  - `OwnedGifts`
- Parse gift service fields on messages:
  - `gift`
  - `unique_gift`
  - `gift_upgrade_sent`
- Type `TransactionPartner#gift` as `Gift?`
- Add gift methods:
  - `get_available_gifts`
  - `send_gift`
  - `gift_premium_subscription`