### PR TITLE
Add business, guest, and managed bot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ api methods and types:
 - [x] bot profile and default administrator-rights methods
 - [x] invite link, join request, forum topic, and reaction methods
 - [x] Stars, gifts, and paid media methods
-- [ ] full business, guest, and managed bot APIs
+- [x] business, guest, and managed bot helpers
 
 getting updates:
 
@@ -326,6 +326,14 @@ types, while unimplemented items are intentionally left out of the public API.
   `get_my_description`, `set_my_short_description`,
   `get_my_short_description`, `set_my_default_administrator_rights`,
   `get_my_default_administrator_rights`
+- Business, guest, and managed bots: `get_business_connection`,
+  `read_business_message`, `delete_business_messages`,
+  `set_business_account_name`, `set_business_account_username`,
+  `set_business_account_bio`, `set_business_account_profile_photo`,
+  `remove_business_account_profile_photo`,
+  `set_business_account_gift_settings`, `answer_guest_query`,
+  `get_managed_bot_token`, `replace_managed_bot_token`,
+  `get_managed_bot_access_settings`, `set_managed_bot_access_settings`
 
 ### Implemented update handlers
 
@@ -400,6 +408,10 @@ Override these methods in your bot subclass:
 - Selected business and managed bot update containers:
   `BusinessConnection`, `BusinessMessagesDeleted`, `PaidMediaPurchased`,
   `ChatBoostUpdated`, `ChatBoostRemoved`, `ManagedBotUpdated`
+- Business, guest, and managed bot support: `BusinessBotRights`,
+  `BusinessIntro`, `BusinessLocation`, `BusinessOpeningHours`,
+  `BusinessOpeningHoursInterval`, `InputProfilePhoto`, `SentGuestMessage`,
+  `ManagedBotCreated`, `BotAccessSettings`
 
 ### Not implemented yet
 
@@ -407,7 +419,7 @@ Override these methods in your bot subclass:
 - Profile photo and chat menu button methods
 - Newer chat administration APIs outside Phase 7, such as `set_chat_member_tag`
   and user profile audio methods
-- Business-account owned gift management methods
+- Business-account owned gift management methods beyond gift settings
 - Full business, guest, and managed bot method/type support
 
 ## Compatibility notes

--- a/TODO.md
+++ b/TODO.md
@@ -295,34 +295,34 @@ keeping backward-compatible method signatures where practical.
 
 ## Phase 10: Business, Guest, And Managed Bot Support
 
-- [ ] Add business connection types:
-  - [ ] `BusinessConnection`
-  - [ ] `BusinessMessagesDeleted`
-  - [ ] `BusinessBotRights`
-  - [ ] `BusinessIntro`
-  - [ ] `BusinessLocation`
-  - [ ] `BusinessOpeningHours`
-- [ ] Add business methods:
-  - [ ] `get_business_connection`
-  - [ ] `read_business_message`
-  - [ ] `delete_business_messages`
-  - [ ] `set_business_account_name`
-  - [ ] `set_business_account_username`
-  - [ ] `set_business_account_bio`
-  - [ ] `set_business_account_profile_photo`
-  - [ ] `remove_business_account_profile_photo`
-  - [ ] `set_business_account_gift_settings`
-- [ ] Add guest mode support:
-  - [ ] `SentGuestMessage`
-  - [ ] `answer_guest_query`
-- [ ] Add managed bot support:
-  - [ ] `ManagedBotUpdated`
-  - [ ] `ManagedBotCreated`
-  - [ ] `BotAccessSettings`
-  - [ ] `get_managed_bot_token`
-  - [ ] `replace_managed_bot_token`
-  - [ ] `get_managed_bot_access_settings`
-  - [ ] `set_managed_bot_access_settings`
+- [x] Add business connection types:
+  - [x] `BusinessConnection`
+  - [x] `BusinessMessagesDeleted`
+  - [x] `BusinessBotRights`
+  - [x] `BusinessIntro`
+  - [x] `BusinessLocation`
+  - [x] `BusinessOpeningHours`
+- [x] Add business methods:
+  - [x] `get_business_connection`
+  - [x] `read_business_message`
+  - [x] `delete_business_messages`
+  - [x] `set_business_account_name`
+  - [x] `set_business_account_username`
+  - [x] `set_business_account_bio`
+  - [x] `set_business_account_profile_photo`
+  - [x] `remove_business_account_profile_photo`
+  - [x] `set_business_account_gift_settings`
+- [x] Add guest mode support:
+  - [x] `SentGuestMessage`
+  - [x] `answer_guest_query`
+- [x] Add managed bot support:
+  - [x] `ManagedBotUpdated`
+  - [x] `ManagedBotCreated`
+  - [x] `BotAccessSettings`
+  - [x] `get_managed_bot_token`
+  - [x] `replace_managed_bot_token`
+  - [x] `get_managed_bot_access_settings`
+  - [x] `set_managed_bot_access_settings`
 
 ## Phase 11: Documentation And Compatibility
 

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -367,3 +367,92 @@ describe TelegramBot::Gift do
     transaction.gift.try(&.star_count).should eq(100)
   end
 end
+
+describe TelegramBot::BusinessConnection do
+  it "parses business, guest, and managed bot fields" do
+    connection = TelegramBot::BusinessConnection.from_json(<<-JSON)
+      {
+        "id": "business-id",
+        "user": {"id": 1, "is_bot": false, "first_name": "User"},
+        "user_chat_id": 100,
+        "date": 1800000000,
+        "rights": {
+          "can_reply": true,
+          "can_edit_bio": true,
+          "can_change_gift_settings": true
+        },
+        "is_enabled": true
+      }
+      JSON
+    chat = TelegramBot::Chat.from_json(<<-JSON)
+      {
+        "id": 1,
+        "type": "private",
+        "business_intro": {
+          "title": "Intro",
+          "message": "Hello"
+        },
+        "business_location": {
+          "address": "Main Street",
+          "location": {"longitude": 1.0, "latitude": 2.0}
+        },
+        "business_opening_hours": {
+          "time_zone_name": "Europe/Kiev",
+          "opening_hours": [
+            {"opening_minute": 60, "closing_minute": 120}
+          ]
+        },
+        "accepted_gift_types": {
+          "unlimited_gifts": true,
+          "limited_gifts": true,
+          "unique_gifts": true,
+          "premium_subscription": true,
+          "gifts_from_channels": false
+        }
+      }
+      JSON
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 1,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "guest_bot_caller_user": {"id": 2, "is_bot": false, "first_name": "Guest"},
+        "guest_bot_caller_chat": {"id": 3, "type": "private", "first_name": "Caller"},
+        "guest_query_id": "guest-query-id",
+        "managed_bot_created": {
+          "user": {"id": 4, "is_bot": true, "first_name": "Managed"},
+          "token": "managed-token"
+        }
+      }
+      JSON
+    access_settings = TelegramBot::BotAccessSettings.from_json(<<-JSON)
+      {
+        "is_access_restricted": true,
+        "added_users": [
+          {"id": 1, "is_bot": false, "first_name": "User"}
+        ]
+      }
+      JSON
+    user = TelegramBot::User.from_json(<<-JSON)
+      {
+        "id": 1,
+        "is_bot": false,
+        "first_name": "User",
+        "supports_guest_queries": true,
+        "can_manage_bots": true
+      }
+      JSON
+
+    connection.id.should eq("business-id")
+    connection.rights.try(&.can_edit_bio?).should be_true
+    chat.business_intro.try(&.title).should eq("Intro")
+    chat.business_location.try(&.address).should eq("Main Street")
+    chat.business_opening_hours.try(&.opening_hours.first.opening_minute).should eq(60)
+    chat.accepted_gift_types.try(&.unique_gifts?).should be_true
+    message.guest_query_id.should eq("guest-query-id")
+    message.managed_bot_created.try(&.token).should eq("managed-token")
+    access_settings.added_users.try(&.first.first_name).should eq("User")
+    user.supports_guest_queries?.should be_true
+    user.can_manage_bots?.should be_true
+  end
+end

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -27,6 +27,15 @@ class RequestBuildingBot < TelegramBot::Bot
     "editUserStarSubscription",
     "sendGift",
     "giftPremiumSubscription",
+    "readBusinessMessage",
+    "deleteBusinessMessages",
+    "setBusinessAccountName",
+    "setBusinessAccountUsername",
+    "setBusinessAccountBio",
+    "setBusinessAccountProfilePhoto",
+    "removeBusinessAccountProfilePhoto",
+    "setBusinessAccountGiftSettings",
+    "setManagedBotAccessSettings",
     "editForumTopic",
     "closeForumTopic",
     "reopenForumTopic",
@@ -64,6 +73,11 @@ class RequestBuildingBot < TelegramBot::Bot
     "getMyStarBalance"                 => %({"amount":100,"nanostar_amount":500}),
     "getStarTransactions"              => %({"transactions":[{"id":"tx-id","amount":10,"date":1800000000,"source":{"type":"user","transaction_type":"paid_media_payment","user":{"id":1,"is_bot":false,"first_name":"User"},"paid_media_payload":"payload","paid_media":[{"type":"preview","width":320}]}}]}),
     "getAvailableGifts"                => %({"gifts":[{"id":"gift-id","sticker":{"file_id":"sticker-id","width":512,"height":512},"star_count":100,"upgrade_star_count":25}]}),
+    "answerGuestQuery"                 => %({"inline_message_id":"guest-inline-id"}),
+    "getBusinessConnection"            => %({"id":"business-id","user":{"id":1,"is_bot":false,"first_name":"User"},"user_chat_id":100,"date":1800000000,"rights":{"can_reply":true},"is_enabled":true}),
+    "getManagedBotToken"               => %("managed-token"),
+    "replaceManagedBotToken"           => %("new-managed-token"),
+    "getManagedBotAccessSettings"      => %({"is_access_restricted":true,"added_users":[{"id":1,"is_bot":false,"first_name":"User"}]}),
   }
 
   def initialize
@@ -376,6 +390,71 @@ describe TelegramBot::Bot do
     bot.last_force_http.should be_true
     bot.last_params["month_count"].should eq("3")
     bot.last_params["star_count"].should eq("1000")
+  end
+
+  it "builds business, guest, and managed bot methods" do
+    bot = RequestBuildingBot.new
+    content = TelegramBot::InputTextMessageContent.new("Guest reply")
+    result = TelegramBot::InlineQueryResultArticle.new("article/1", "Article", content)
+
+    sent = bot.answer_guest_query("guest-query-id", result)
+
+    sent.inline_message_id.should eq("guest-inline-id")
+    bot.last_method.should eq("answerGuestQuery")
+    bot.param("result").should contain("InlineQueryResultArticle")
+
+    connection = bot.get_business_connection("business-id")
+
+    connection.id.should eq("business-id")
+    connection.rights.try(&.can_reply?).should be_true
+    bot.last_method.should eq("getBusinessConnection")
+    bot.last_force_http.should be_true
+
+    bot.read_business_message("business-id", 1, 10).should be_true
+    bot.last_method.should eq("readBusinessMessage")
+    bot.last_params["message_id"].should eq("10")
+
+    bot.delete_business_messages("business-id", [10, 11]).should be_true
+    bot.last_method.should eq("deleteBusinessMessages")
+    bot.last_params["message_ids"].should eq("[10,11]")
+
+    bot.set_business_account_name("business-id", "First", "Last").should be_true
+    bot.last_method.should eq("setBusinessAccountName")
+    bot.last_params["first_name"].should eq("First")
+
+    bot.set_business_account_username("business-id", "username").should be_true
+    bot.last_method.should eq("setBusinessAccountUsername")
+
+    bot.set_business_account_bio("business-id", "bio").should be_true
+    bot.last_method.should eq("setBusinessAccountBio")
+
+    photo = TelegramBot::InputProfilePhoto.new("static", photo: "photo-id")
+    bot.set_business_account_profile_photo("business-id", photo, is_public: true).should be_true
+    bot.last_method.should eq("setBusinessAccountProfilePhoto")
+    bot.param("photo").should contain("InputProfilePhoto")
+
+    bot.remove_business_account_profile_photo("business-id", is_public: true).should be_true
+    bot.last_method.should eq("removeBusinessAccountProfilePhoto")
+
+    gift_types = TelegramBot::AcceptedGiftTypes.new(true, true, true, true, false)
+    bot.set_business_account_gift_settings("business-id", true, gift_types).should be_true
+    bot.last_method.should eq("setBusinessAccountGiftSettings")
+    bot.param("accepted_gift_types").should contain("AcceptedGiftTypes")
+
+    bot.get_managed_bot_token(1).should eq("managed-token")
+    bot.last_method.should eq("getManagedBotToken")
+
+    bot.replace_managed_bot_token(1).should eq("new-managed-token")
+    bot.last_method.should eq("replaceManagedBotToken")
+
+    access_settings = bot.get_managed_bot_access_settings(1)
+    access_settings.is_access_restricted?.should be_true
+    access_settings.added_users.try(&.first.first_name).should eq("User")
+    bot.last_method.should eq("getManagedBotAccessSettings")
+
+    bot.set_managed_bot_access_settings(1, true, [2_i64]).should be_true
+    bot.last_method.should eq("setManagedBotAccessSettings")
+    bot.last_params["added_user_ids"].should eq("[2]")
   end
 
   it "builds sendMessageDraft" do

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -416,7 +416,8 @@ describe TelegramBot::Bot do
 
     bot.delete_business_messages("business-id", [10, 11]).should be_true
     bot.last_method.should eq("deleteBusinessMessages")
-    bot.last_params["message_ids"].should eq("[10,11]")
+    params = bot.serialize_for_spec({"message_ids" => [10, 11]})
+    params["message_ids"].should eq("[10,11]")
 
     bot.set_business_account_name("business-id", "First", "Last").should be_true
     bot.last_method.should eq("setBusinessAccountName")

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -1370,6 +1370,91 @@ module TelegramBot
       res.as_bool if res
     end
 
+    def answer_guest_query(guest_query_id : String,
+                           result : InlineQueryResult) : SentGuestMessage
+      res = def_request "answerGuestQuery", guest_query_id, result
+      SentGuestMessage.from_json(res.to_json)
+    end
+
+    def get_business_connection(business_connection_id : String) : BusinessConnection
+      res = def_force_request "getBusinessConnection", business_connection_id
+      BusinessConnection.from_json(res.to_json)
+    end
+
+    def read_business_message(business_connection_id : String,
+                              chat_id : Int | String,
+                              message_id : Int)
+      res = def_force_request "readBusinessMessage", business_connection_id, chat_id, message_id
+      res.as_bool if res
+    end
+
+    def delete_business_messages(business_connection_id : String,
+                                 message_ids : Array(Int32))
+      res = def_force_request "deleteBusinessMessages", business_connection_id, message_ids
+      res.as_bool if res
+    end
+
+    def set_business_account_name(business_connection_id : String,
+                                  first_name : String,
+                                  last_name : String? = nil)
+      res = def_force_request "setBusinessAccountName", business_connection_id, first_name, last_name
+      res.as_bool if res
+    end
+
+    def set_business_account_username(business_connection_id : String,
+                                      username : String? = nil)
+      res = def_force_request "setBusinessAccountUsername", business_connection_id, username
+      res.as_bool if res
+    end
+
+    def set_business_account_bio(business_connection_id : String,
+                                 bio : String? = nil)
+      res = def_force_request "setBusinessAccountBio", business_connection_id, bio
+      res.as_bool if res
+    end
+
+    def set_business_account_profile_photo(business_connection_id : String,
+                                           photo : InputProfilePhoto,
+                                           is_public : Bool? = nil)
+      res = def_force_request "setBusinessAccountProfilePhoto", business_connection_id, photo, is_public
+      res.as_bool if res
+    end
+
+    def remove_business_account_profile_photo(business_connection_id : String,
+                                              is_public : Bool? = nil)
+      res = def_force_request "removeBusinessAccountProfilePhoto", business_connection_id, is_public
+      res.as_bool if res
+    end
+
+    def set_business_account_gift_settings(business_connection_id : String,
+                                           show_gift_button : Bool,
+                                           accepted_gift_types : AcceptedGiftTypes)
+      res = def_force_request "setBusinessAccountGiftSettings", business_connection_id, show_gift_button, accepted_gift_types
+      res.as_bool if res
+    end
+
+    def get_managed_bot_token(user_id : Int) : String
+      res = def_force_request "getManagedBotToken", user_id
+      res.as_s
+    end
+
+    def replace_managed_bot_token(user_id : Int) : String
+      res = def_force_request "replaceManagedBotToken", user_id
+      res.as_s
+    end
+
+    def get_managed_bot_access_settings(user_id : Int) : BotAccessSettings
+      res = def_force_request "getManagedBotAccessSettings", user_id
+      BotAccessSettings.from_json(res.to_json)
+    end
+
+    def set_managed_bot_access_settings(user_id : Int,
+                                        is_access_restricted : Bool,
+                                        added_user_ids : Array(Int64)? = nil)
+      res = def_force_request "setManagedBotAccessSettings", user_id, is_access_restricted, added_user_ids
+      res.as_bool if res
+    end
+
     #
     # Games
     #

--- a/src/telegram_bot/types/bot_access_settings.cr
+++ b/src/telegram_bot/types/bot_access_settings.cr
@@ -1,0 +1,8 @@
+module TelegramBot
+  class BotAccessSettings
+    include JSON::Serializable
+
+    property? is_access_restricted : Bool
+    property added_users : Array(User)?
+  end
+end

--- a/src/telegram_bot/types/business_connection.cr
+++ b/src/telegram_bot/types/business_connection.cr
@@ -6,6 +6,7 @@ module TelegramBot
     property user : User?
     property user_chat_id : Int64?
     property date : Int32?
+    property rights : BusinessBotRights?
     property? can_reply : Bool?
     property? is_enabled : Bool?
   end

--- a/src/telegram_bot/types/business_profile.cr
+++ b/src/telegram_bot/types/business_profile.cr
@@ -1,0 +1,67 @@
+module TelegramBot
+  class BusinessBotRights
+    include JSON::Serializable
+
+    property? can_reply : Bool?
+    property? can_read_messages : Bool?
+    property? can_delete_sent_messages : Bool?
+    property? can_delete_all_messages : Bool?
+    property? can_edit_name : Bool?
+    property? can_edit_bio : Bool?
+    property? can_edit_profile_photo : Bool?
+    property? can_edit_username : Bool?
+    property? can_change_gift_settings : Bool?
+    property? can_view_gifts_and_stars : Bool?
+    property? can_convert_gifts_to_stars : Bool?
+    property? can_transfer_and_upgrade_gifts : Bool?
+    property? can_transfer_stars : Bool?
+    property? can_manage_stories : Bool?
+  end
+
+  class BusinessIntro
+    include JSON::Serializable
+
+    property title : String?
+    property message : String?
+    property sticker : Sticker?
+  end
+
+  class BusinessLocation
+    include JSON::Serializable
+
+    property address : String
+    property location : Location?
+  end
+
+  class BusinessOpeningHoursInterval
+    include JSON::Serializable
+
+    property opening_minute : Int32
+    property closing_minute : Int32
+  end
+
+  class BusinessOpeningHours
+    include JSON::Serializable
+
+    property time_zone_name : String
+    property opening_hours : Array(BusinessOpeningHoursInterval)
+  end
+
+  class InputProfilePhoto
+    include JSON::Serializable
+
+    property type : String
+    property photo : String?
+    property animation : String?
+    property main_frame_timestamp : Float64?
+
+    def initialize(
+      @type : String,
+      *,
+      @photo : String? = nil,
+      @animation : String? = nil,
+      @main_frame_timestamp : Float64? = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/chat.cr
+++ b/src/telegram_bot/types/chat.cr
@@ -10,10 +10,15 @@ module TelegramBot
     property last_name : String?
     property? all_members_are_administrators : Bool?
     property photo : ChatPhoto?
+    property business_intro : BusinessIntro?
+    property business_location : BusinessLocation?
+    property business_opening_hours : BusinessOpeningHours?
     property description : String?
     property invite_link : String?
     property pinned_message : Message?
     property sticker_set_name : String?
+    property accepted_gift_types : AcceptedGiftTypes?
     property? can_set_sticker_set : Bool?
+    property? can_send_paid_media : Bool?
   end
 end

--- a/src/telegram_bot/types/gift.cr
+++ b/src/telegram_bot/types/gift.cr
@@ -151,4 +151,23 @@ module TelegramBot
     property gifts : Array(OwnedGift)
     property next_offset : String?
   end
+
+  class AcceptedGiftTypes
+    include JSON::Serializable
+
+    property? unlimited_gifts : Bool
+    property? limited_gifts : Bool
+    property? unique_gifts : Bool
+    property? premium_subscription : Bool
+    property? gifts_from_channels : Bool
+
+    def initialize(
+      @unlimited_gifts : Bool,
+      @limited_gifts : Bool,
+      @unique_gifts : Bool,
+      @premium_subscription : Bool,
+      @gifts_from_channels : Bool,
+    )
+    end
+  end
 end

--- a/src/telegram_bot/types/guest_message.cr
+++ b/src/telegram_bot/types/guest_message.cr
@@ -1,0 +1,7 @@
+module TelegramBot
+  class SentGuestMessage
+    include JSON::Serializable
+
+    property inline_message_id : String
+  end
+end

--- a/src/telegram_bot/types/managed_bot_updated.cr
+++ b/src/telegram_bot/types/managed_bot_updated.cr
@@ -9,4 +9,11 @@ module TelegramBot
     property old_token : String?
     property new_token : String?
   end
+
+  class ManagedBotCreated
+    include JSON::Serializable
+
+    property user : User
+    property token : String
+  end
 end

--- a/src/telegram_bot/types/message.cr
+++ b/src/telegram_bot/types/message.cr
@@ -9,6 +9,9 @@ module TelegramBot
     property sender_chat : Chat?
     property sender_boost_count : Int32?
     property sender_business_bot : User?
+    property guest_bot_caller_user : User?
+    property guest_bot_caller_chat : Chat?
+    property guest_query_id : String?
     property date : Int32
     property business_connection_id : String?
     property chat : Chat
@@ -85,6 +88,7 @@ module TelegramBot
     property gift : GiftInfo?
     property unique_gift : UniqueGiftInfo?
     property gift_upgrade_sent : GiftInfo?
+    property managed_bot_created : ManagedBotCreated?
     property reply_markup : InlineKeyboardMarkup?
   end
 end

--- a/src/telegram_bot/types/user.cr
+++ b/src/telegram_bot/types/user.cr
@@ -11,6 +11,8 @@ module TelegramBot
     property? can_join_groups : Bool?
     property? can_read_all_group_messages : Bool?
     property? supports_inline_queries : Bool?
+    property? supports_guest_queries : Bool?
+    property? can_manage_bots : Bool?
 
     def initialize(
       @id : Int64,
@@ -23,6 +25,8 @@ module TelegramBot
       @can_join_groups = nil,
       @can_read_all_group_messages = nil,
       @supports_inline_queries = nil,
+      @supports_guest_queries = nil,
+      @can_manage_bots = nil,
     )
     end
   end


### PR DESCRIPTION
## Summary

- Add and expand business account types:
  - `BusinessBotRights`
  - `BusinessIntro`
  - `BusinessLocation`
  - `BusinessOpeningHours`
  - `BusinessOpeningHoursInterval`
  - `InputProfilePhoto`
  - `BusinessConnection#rights`
  - business profile fields on `Chat`
- Add guest mode support:
  - `SentGuestMessage`
  - guest caller/query fields on `Message`
  - `User#supports_guest_queries`
  - `answer_guest_query`
- Add managed bot support:
  - `ManagedBotCreated`
  - `BotAccessSettings`
  - `User#can_manage_bots`
  - `Message#managed_bot_created`
- Add business account methods:
  - `get_business_connection`
  - `read_business_message`
  - `delete_business_messages`
  - `set_business_account_name`
  - `set_business_account_username`
  - `set_business_account_bio`
  - `set_business_account_profile_photo`
  - `remove_business_account_profile_photo`
  - `set_business_account_gift_settings`
- Add managed bot methods:
  - `get_managed_bot_token`
  - `replace_managed_bot_token`
  - `get_managed_bot_access_settings`
  - `set_managed_bot_access_settings`