### PR TITLE
Add block-based update handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,14 @@ A minimal echo bot with long polling:
 ```crystal
 require "telegram_bot"
 
-class EchoBot < TelegramBot::Bot
-  def handle(message : TelegramBot::Message)
-    return unless text = message.text
+bot = TelegramBot::Bot.new("echo_bot", ENV["TELEGRAM_BOT_TOKEN"])
 
-    send_message(message.chat.id, "You said: #{text}")
-  end
+bot.on_message do |message|
+  next unless text = message.text
+
+  bot.send_message(message.chat.id, "You said: #{text}")
 end
 
-bot = EchoBot.new("echo_bot", ENV["TELEGRAM_BOT_TOKEN"])
 bot.polling
 ```
 
@@ -71,10 +70,11 @@ additional features:
 
 - [x] allow & block lists
 - [x] command handler
+- [x] block-based update handlers
 
 ## Usage
 
-Create your bot by inheriting from `TelegramBot::Bot`.
+For structured bots, create your bot by inheriting from `TelegramBot::Bot`.
 
 ### Commands
 

--- a/spec/telegram_bot_spec.cr
+++ b/spec/telegram_bot_spec.cr
@@ -10,6 +10,11 @@ class TestBot < TelegramBot::Bot
       send_message msg.chat.id, "test"
     end
   end
+
+  protected def request(method : String, force_http : Bool = false, params = nil)
+    Fiber.yield
+    JSON.parse("[]")
+  end
 end
 
 class OverrideHandlerBot < TelegramBot::Bot
@@ -31,18 +36,19 @@ describe TelegramBot do
   end
 
   it "logs messages" do
-    IO.pipe do |reader, writer|
-      test = TestBot.new
-      TestBot::Log.level = :debug
-      TestBot::Log.backend = ::Log::IOBackend.new(writer)
+    io = IO::Memory.new
+    test = TestBot.new
+    TestBot::Log.level = :debug
+    TestBot::Log.backend = ::Log::IOBackend.new(io)
 
-      spawn { test.polling }
-      Fiber.yield
-      test.stop
+    spawn { test.polling }
+    Fiber.yield
+    test.stop
+    Fiber.yield
 
-      reader.gets.should match(/TestBot is ready to lead/)
-      reader.gets.should match(/TestBot is going to take a rest/)
-    end
+    logs = io.to_s
+    logs.should match(/TestBot is ready to lead/)
+    logs.should match(/TestBot is going to take a rest/)
   end
 
   it "dispatches messages to registered block handlers" do

--- a/spec/telegram_bot_spec.cr
+++ b/spec/telegram_bot_spec.cr
@@ -12,6 +12,19 @@ class TestBot < TelegramBot::Bot
   end
 end
 
+class OverrideHandlerBot < TelegramBot::Bot
+  getter handled_message : String?
+
+  def initialize
+    super "overridebot", ""
+    @handled_message = nil.as(String?)
+  end
+
+  def handle(message : TelegramBot::Message)
+    @handled_message = message.text
+  end
+end
+
 describe TelegramBot do
   it "works" do
     TestBot.new
@@ -29,6 +42,122 @@ describe TelegramBot do
 
       reader.gets.should match(/TestBot is ready to lead/)
       reader.gets.should match(/TestBot is going to take a rest/)
+    end
+  end
+
+  it "dispatches messages to registered block handlers" do
+    bot = TelegramBot::Bot.new("blockbot", "")
+    handled_message = nil.as(String?)
+
+    bot.on_message do |message|
+      handled_message = message.text
+    end
+
+    bot.handle_update(TelegramBot::Update.from_json(<<-JSON))
+      {
+        "update_id": 1,
+        "message": {
+          "message_id": 10,
+          "date": 0,
+          "chat": {"id": 1, "type": "private"},
+          "from": {"id": 1, "is_bot": false, "first_name": "User", "username": "allowed"},
+          "text": "hello"
+        }
+      }
+      JSON
+
+    handled_message.should eq("hello")
+  end
+
+  it "keeps subclass handlers authoritative over registered block handlers" do
+    bot = OverrideHandlerBot.new
+    block_called = false
+
+    bot.on_message do |_message|
+      block_called = true
+    end
+
+    bot.handle_update(TelegramBot::Update.from_json(<<-JSON))
+      {
+        "update_id": 1,
+        "message": {
+          "message_id": 10,
+          "date": 0,
+          "chat": {"id": 1, "type": "private"},
+          "text": "override"
+        }
+      }
+      JSON
+
+    bot.handled_message.should eq("override")
+    block_called.should be_false
+  end
+
+  it "applies allowlist filtering before registered block handlers" do
+    bot = TelegramBot::Bot.new("blockbot", "", allowlist: ["allowed"])
+    block_called = false
+
+    bot.on_message do |_message|
+      block_called = true
+    end
+
+    bot.handle_update(TelegramBot::Update.from_json(<<-JSON))
+      {
+        "update_id": 1,
+        "message": {
+          "message_id": 10,
+          "date": 0,
+          "chat": {"id": 1, "type": "private"},
+          "from": {"id": 1, "is_bot": false, "first_name": "User", "username": "blocked"},
+          "text": "hello"
+        }
+      }
+      JSON
+
+    block_called.should be_false
+  end
+
+  it "applies blocklist filtering before registered block handlers" do
+    bot = TelegramBot::Bot.new("blockbot", "", blocklist: ["blocked"])
+    block_called = false
+
+    bot.on_message do |_message|
+      block_called = true
+    end
+
+    bot.handle_update(TelegramBot::Update.from_json(<<-JSON))
+      {
+        "update_id": 1,
+        "message": {
+          "message_id": 10,
+          "date": 0,
+          "chat": {"id": 1, "type": "private"},
+          "from": {"id": 1, "is_bot": false, "first_name": "User", "username": "blocked"},
+          "text": "hello"
+        }
+      }
+      JSON
+
+    block_called.should be_false
+  end
+
+  it "allows concrete bots without subclassing" do
+    TelegramBot::Bot.new("blockbot", "")
+  end
+
+  it "preserves default handler errors when no block handler is registered" do
+    bot = TelegramBot::Bot.new("blockbot", "")
+    message = TelegramBot::Message.from_json(<<-JSON)
+      {
+        "message_id": 10,
+        "date": 0,
+        "chat": {"id": 1, "type": "private"},
+        "text": "hello"
+      }
+      JSON
+
+    expect_raises(Exception, "message handler is not implemented") do
+      bot.handle(message)
     end
   end
 end

--- a/src/telegram_bot/bot.cr
+++ b/src/telegram_bot/bot.cr
@@ -12,8 +12,27 @@ require "./response_client.cr"
 require "./api_exception.cr"
 
 module TelegramBot
-  abstract class Bot
+  class Bot
     Log = ::Log.for(self)
+
+    alias MessageHandler = Proc(Message, Nil)
+    alias InlineQueryHandler = Proc(InlineQuery, Nil)
+    alias ChosenInlineResultHandler = Proc(ChosenInlineResult, Nil)
+    alias CallbackQueryHandler = Proc(CallbackQuery, Nil)
+    alias BusinessConnectionHandler = Proc(BusinessConnection, Nil)
+    alias BusinessMessagesDeletedHandler = Proc(BusinessMessagesDeleted, Nil)
+    alias MessageReactionUpdatedHandler = Proc(MessageReactionUpdated, Nil)
+    alias MessageReactionCountUpdatedHandler = Proc(MessageReactionCountUpdated, Nil)
+    alias ShippingQueryHandler = Proc(ShippingQuery, Nil)
+    alias PreCheckoutQueryHandler = Proc(PreCheckoutQuery, Nil)
+    alias PaidMediaPurchasedHandler = Proc(PaidMediaPurchased, Nil)
+    alias PollHandler = Proc(Poll, Nil)
+    alias PollAnswerHandler = Proc(PollAnswer, Nil)
+    alias ChatMemberUpdatedHandler = Proc(ChatMemberUpdated, Nil)
+    alias ChatJoinRequestHandler = Proc(ChatJoinRequest, Nil)
+    alias ChatBoostUpdatedHandler = Proc(ChatBoostUpdated, Nil)
+    alias ChatBoostRemovedHandler = Proc(ChatBoostRemoved, Nil)
+    alias ManagedBotUpdatedHandler = Proc(ManagedBotUpdated, Nil)
 
     def initialize(
       @name : String,
@@ -25,6 +44,31 @@ module TelegramBot
     )
       @nextoffset = 0
       @running = false
+      @message_handler = nil.as(MessageHandler?)
+      @edited_message_handler = nil.as(MessageHandler?)
+      @channel_post_handler = nil.as(MessageHandler?)
+      @edited_channel_post_handler = nil.as(MessageHandler?)
+      @inline_query_handler = nil.as(InlineQueryHandler?)
+      @chosen_inline_result_handler = nil.as(ChosenInlineResultHandler?)
+      @callback_query_handler = nil.as(CallbackQueryHandler?)
+      @business_connection_handler = nil.as(BusinessConnectionHandler?)
+      @business_message_handler = nil.as(MessageHandler?)
+      @edited_business_message_handler = nil.as(MessageHandler?)
+      @deleted_business_messages_handler = nil.as(BusinessMessagesDeletedHandler?)
+      @guest_message_handler = nil.as(MessageHandler?)
+      @message_reaction_handler = nil.as(MessageReactionUpdatedHandler?)
+      @message_reaction_count_handler = nil.as(MessageReactionCountUpdatedHandler?)
+      @shipping_query_handler = nil.as(ShippingQueryHandler?)
+      @pre_checkout_query_handler = nil.as(PreCheckoutQueryHandler?)
+      @purchased_paid_media_handler = nil.as(PaidMediaPurchasedHandler?)
+      @poll_handler = nil.as(PollHandler?)
+      @poll_answer_handler = nil.as(PollAnswerHandler?)
+      @my_chat_member_handler = nil.as(ChatMemberUpdatedHandler?)
+      @chat_member_handler = nil.as(ChatMemberUpdatedHandler?)
+      @chat_join_request_handler = nil.as(ChatJoinRequestHandler?)
+      @chat_boost_handler = nil.as(ChatBoostUpdatedHandler?)
+      @removed_chat_boost_handler = nil.as(ChatBoostRemovedHandler?)
+      @managed_bot_handler = nil.as(ManagedBotUpdatedHandler?)
     end
   end
 end

--- a/src/telegram_bot/bot/methods/chat.cr
+++ b/src/telegram_bot/bot/methods/chat.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sends a chat action indicator.
     #
     # See: <https://core.telegram.org/bots/api#sendchataction>

--- a/src/telegram_bot/bot/methods/files.cr
+++ b/src/telegram_bot/bot/methods/files.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Returns file metadata and a download path.
     #
     # See: <https://core.telegram.org/bots/api#getfile>

--- a/src/telegram_bot/bot/methods/games.cr
+++ b/src/telegram_bot/bot/methods/games.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sends a game.
     #
     # See: <https://core.telegram.org/bots/api#sendgame>

--- a/src/telegram_bot/bot/methods/gifts_business.cr
+++ b/src/telegram_bot/bot/methods/gifts_business.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Returns gifts that can be sent by the bot.
     #
     # See: <https://core.telegram.org/bots/api#getavailablegifts>

--- a/src/telegram_bot/bot/methods/inline.cr
+++ b/src/telegram_bot/bot/methods/inline.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sends an answer to a callback query.
     #
     # See: <https://core.telegram.org/bots/api#answercallbackquery>

--- a/src/telegram_bot/bot/methods/payments.cr
+++ b/src/telegram_bot/bot/methods/payments.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sends invoices.
     #
     # See: <https://core.telegram.org/bots/api#sendinvoice>

--- a/src/telegram_bot/bot/methods/profile.cr
+++ b/src/telegram_bot/bot/methods/profile.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Returns the bot's command list.
     #
     # See: <https://core.telegram.org/bots/api#getmycommands>

--- a/src/telegram_bot/bot/methods/sending.cr
+++ b/src/telegram_bot/bot/methods/sending.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sends text messages.
     #
     # See: <https://core.telegram.org/bots/api#sendmessage>

--- a/src/telegram_bot/bot/methods/stickers.cr
+++ b/src/telegram_bot/bot/methods/stickers.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Returns a sticker set.
     #
     # See: <https://core.telegram.org/bots/api#getstickerset>

--- a/src/telegram_bot/bot/methods/webhooks.cr
+++ b/src/telegram_bot/bot/methods/webhooks.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     # Sets a webhook for receiving incoming updates.
     #
     # See: <https://core.telegram.org/bots/api#setwebhook>

--- a/src/telegram_bot/bot/requests.cr
+++ b/src/telegram_bot/bot/requests.cr
@@ -1,5 +1,5 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
     protected def request(
       method : String,
       force_http : Bool = false,

--- a/src/telegram_bot/bot/updates.cr
+++ b/src/telegram_bot/bot/updates.cr
@@ -1,125 +1,350 @@
 module TelegramBot
-  abstract class Bot
+  class Bot
+    # Registers a block handler for incoming messages.
+    def on_message(&block : Message -> _)
+      @message_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for edited messages.
+    def on_edited_message(&block : Message -> _)
+      @edited_message_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for channel posts.
+    def on_channel_post(&block : Message -> _)
+      @channel_post_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for edited channel posts.
+    def on_edited_channel_post(&block : Message -> _)
+      @edited_channel_post_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for inline queries.
+    def on_inline_query(&block : InlineQuery -> _)
+      @inline_query_handler = ->(inline_query : InlineQuery) { block.call(inline_query); nil }
+    end
+
+    # Registers a block handler for chosen inline results.
+    def on_chosen_inline_result(&block : ChosenInlineResult -> _)
+      @chosen_inline_result_handler = ->(chosen_inline_result : ChosenInlineResult) { block.call(chosen_inline_result); nil }
+    end
+
+    # Registers a block handler for callback queries.
+    def on_callback_query(&block : CallbackQuery -> _)
+      @callback_query_handler = ->(callback_query : CallbackQuery) { block.call(callback_query); nil }
+    end
+
+    # Registers a block handler for business connection updates.
+    def on_business_connection(&block : BusinessConnection -> _)
+      @business_connection_handler = ->(business_connection : BusinessConnection) { block.call(business_connection); nil }
+    end
+
+    # Registers a block handler for business messages.
+    def on_business_message(&block : Message -> _)
+      @business_message_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for edited business messages.
+    def on_edited_business_message(&block : Message -> _)
+      @edited_business_message_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for deleted business message updates.
+    def on_deleted_business_messages(&block : BusinessMessagesDeleted -> _)
+      @deleted_business_messages_handler = ->(deleted_business_messages : BusinessMessagesDeleted) { block.call(deleted_business_messages); nil }
+    end
+
+    # Registers a block handler for guest messages.
+    def on_guest_message(&block : Message -> _)
+      @guest_message_handler = ->(message : Message) { block.call(message); nil }
+    end
+
+    # Registers a block handler for message reaction updates.
+    def on_message_reaction(&block : MessageReactionUpdated -> _)
+      @message_reaction_handler = ->(message_reaction : MessageReactionUpdated) { block.call(message_reaction); nil }
+    end
+
+    # Registers a block handler for message reaction count updates.
+    def on_message_reaction_count(&block : MessageReactionCountUpdated -> _)
+      @message_reaction_count_handler = ->(message_reaction_count : MessageReactionCountUpdated) { block.call(message_reaction_count); nil }
+    end
+
+    # Registers a block handler for shipping queries.
+    def on_shipping_query(&block : ShippingQuery -> _)
+      @shipping_query_handler = ->(shipping_query : ShippingQuery) { block.call(shipping_query); nil }
+    end
+
+    # Registers a block handler for pre-checkout queries.
+    def on_pre_checkout_query(&block : PreCheckoutQuery -> _)
+      @pre_checkout_query_handler = ->(pre_checkout_query : PreCheckoutQuery) { block.call(pre_checkout_query); nil }
+    end
+
+    # Registers a block handler for purchased paid media updates.
+    def on_purchased_paid_media(&block : PaidMediaPurchased -> _)
+      @purchased_paid_media_handler = ->(purchased_paid_media : PaidMediaPurchased) { block.call(purchased_paid_media); nil }
+    end
+
+    # Registers a block handler for poll updates.
+    def on_poll(&block : Poll -> _)
+      @poll_handler = ->(poll : Poll) { block.call(poll); nil }
+    end
+
+    # Registers a block handler for poll answer updates.
+    def on_poll_answer(&block : PollAnswer -> _)
+      @poll_answer_handler = ->(poll_answer : PollAnswer) { block.call(poll_answer); nil }
+    end
+
+    # Registers a block handler for bot chat member status updates.
+    def on_my_chat_member(&block : ChatMemberUpdated -> _)
+      @my_chat_member_handler = ->(my_chat_member : ChatMemberUpdated) { block.call(my_chat_member); nil }
+    end
+
+    # Registers a block handler for chat member status updates.
+    def on_chat_member(&block : ChatMemberUpdated -> _)
+      @chat_member_handler = ->(chat_member : ChatMemberUpdated) { block.call(chat_member); nil }
+    end
+
+    # Registers a block handler for chat join requests.
+    def on_chat_join_request(&block : ChatJoinRequest -> _)
+      @chat_join_request_handler = ->(chat_join_request : ChatJoinRequest) { block.call(chat_join_request); nil }
+    end
+
+    # Registers a block handler for chat boost updates.
+    def on_chat_boost(&block : ChatBoostUpdated -> _)
+      @chat_boost_handler = ->(chat_boost : ChatBoostUpdated) { block.call(chat_boost); nil }
+    end
+
+    # Registers a block handler for removed chat boost updates.
+    def on_removed_chat_boost(&block : ChatBoostRemoved -> _)
+      @removed_chat_boost_handler = ->(removed_chat_boost : ChatBoostRemoved) { block.call(removed_chat_boost); nil }
+    end
+
+    # Registers a block handler for managed bot updates.
+    def on_managed_bot(&block : ManagedBotUpdated -> _)
+      @managed_bot_handler = ->(managed_bot : ManagedBotUpdated) { block.call(managed_bot); nil }
+    end
+
     # handle messages
     def handle(message : Message)
+      if handler = @message_handler
+        return handler.call(message)
+      end
+
       raise "message handler is not implemented"
     end
 
     # handle edited messages
     def handle_edited(message : Message)
+      if handler = @edited_message_handler
+        return handler.call(message)
+      end
+
       raise "edited message handler is not implemented"
     end
 
     def handle_channel_post(message : Message)
+      if handler = @channel_post_handler
+        return handler.call(message)
+      end
+
       raise "channel post handler is not implemented"
     end
 
     def handle_edited_channel_post(message : Message)
+      if handler = @edited_channel_post_handler
+        return handler.call(message)
+      end
+
       raise "edited channel post handler is not implemented"
     end
 
     # handle inline query
     def handle(inline_query : InlineQuery)
+      if handler = @inline_query_handler
+        return handler.call(inline_query)
+      end
+
       raise "inline_query handler is not implemented"
     end
 
     # handle chosen inlien query
     def handle(chosen_inline_result : ChosenInlineResult)
+      if handler = @chosen_inline_result_handler
+        return handler.call(chosen_inline_result)
+      end
+
       raise "chosen_inline_result handler is not implemented"
     end
 
     # handle callback query
     def handle(callback_query : CallbackQuery)
+      if handler = @callback_query_handler
+        return handler.call(callback_query)
+      end
+
       raise "callback_query handler is not implemented"
     end
 
     # handle business connection updates
     def handle_business_connection(business_connection : BusinessConnection)
+      if handler = @business_connection_handler
+        return handler.call(business_connection)
+      end
+
       raise "business_connection handler is not implemented"
     end
 
     # handle business messages
     def handle_business_message(message : Message)
+      if handler = @business_message_handler
+        return handler.call(message)
+      end
+
       raise "business_message handler is not implemented"
     end
 
     # handle edited business messages
     def handle_edited_business_message(message : Message)
+      if handler = @edited_business_message_handler
+        return handler.call(message)
+      end
+
       raise "edited_business_message handler is not implemented"
     end
 
     # handle deleted business messages
     def handle_deleted_business_messages(deleted_business_messages : BusinessMessagesDeleted)
+      if handler = @deleted_business_messages_handler
+        return handler.call(deleted_business_messages)
+      end
+
       raise "deleted_business_messages handler is not implemented"
     end
 
     # handle guest messages
     def handle_guest_message(message : Message)
+      if handler = @guest_message_handler
+        return handler.call(message)
+      end
+
       raise "guest_message handler is not implemented"
     end
 
     # handle message reaction updates
     def handle(message_reaction : MessageReactionUpdated)
+      if handler = @message_reaction_handler
+        return handler.call(message_reaction)
+      end
+
       raise "message_reaction handler is not implemented"
     end
 
     # handle message reaction count updates
     def handle(message_reaction_count : MessageReactionCountUpdated)
+      if handler = @message_reaction_count_handler
+        return handler.call(message_reaction_count)
+      end
+
       raise "message_reaction_count handler is not implemented"
     end
 
     # handle shipping query
     def handle(shipping_query : ShippingQuery)
+      if handler = @shipping_query_handler
+        return handler.call(shipping_query)
+      end
+
       raise "shipping_query handler is not implemented"
     end
 
     # handle pre-checkout query
     def handle(pre_checkout_query : PreCheckoutQuery)
+      if handler = @pre_checkout_query_handler
+        return handler.call(pre_checkout_query)
+      end
+
       raise "pre_checkout_query handler is not implemented"
     end
 
     # handle purchased paid media updates
     def handle(purchased_paid_media : PaidMediaPurchased)
+      if handler = @purchased_paid_media_handler
+        return handler.call(purchased_paid_media)
+      end
+
       raise "purchased_paid_media handler is not implemented"
     end
 
     # handle poll updates
     def handle(poll : Poll)
+      if handler = @poll_handler
+        return handler.call(poll)
+      end
+
       raise "poll handler is not implemented"
     end
 
     # handle poll answer updates
     def handle(poll_answer : PollAnswer)
+      if handler = @poll_answer_handler
+        return handler.call(poll_answer)
+      end
+
       raise "poll_answer handler is not implemented"
     end
 
     # handle bot chat member status updates
     def handle_my_chat_member(my_chat_member : ChatMemberUpdated)
+      if handler = @my_chat_member_handler
+        return handler.call(my_chat_member)
+      end
+
       raise "my_chat_member handler is not implemented"
     end
 
     # handle chat member status updates
     def handle(chat_member : ChatMemberUpdated)
+      if handler = @chat_member_handler
+        return handler.call(chat_member)
+      end
+
       raise "chat_member handler is not implemented"
     end
 
     # handle chat join requests
     def handle(chat_join_request : ChatJoinRequest)
+      if handler = @chat_join_request_handler
+        return handler.call(chat_join_request)
+      end
+
       raise "chat_join_request handler is not implemented"
     end
 
     # handle chat boost updates
     def handle(chat_boost : ChatBoostUpdated)
+      if handler = @chat_boost_handler
+        return handler.call(chat_boost)
+      end
+
       raise "chat_boost handler is not implemented"
     end
 
     # handle removed chat boost updates
     def handle(removed_chat_boost : ChatBoostRemoved)
+      if handler = @removed_chat_boost_handler
+        return handler.call(removed_chat_boost)
+      end
+
       raise "removed_chat_boost handler is not implemented"
     end
 
     # handle managed bot updates
     def handle(managed_bot : ManagedBotUpdated)
+      if handler = @managed_bot_handler
+        return handler.call(managed_bot)
+      end
+
       raise "managed_bot handler is not implemented"
     end
 


### PR DESCRIPTION
## Summary

Adds block-based update handlers as a friendlier API for small bots while keeping the existing subclass/override model intact.

## Changes

- Make `TelegramBot::Bot` instantiable
- Add `on_*` handler registration methods for supported update types
- Route default `handle(...)` methods through registered block handlers when present
- Preserve existing subclass override behavior
- Preserve existing default handler errors when no handler is registered
- Keep allowlist/blocklist filtering before block handler dispatch
- Update the README quick-start echo bot to use block handlers
- Mark the update handling TODO items as complete

## Compatibility

Existing bots that subclass `TelegramBot::Bot`, override `handle(...)`, and call Bot API methods directly should continue to work. Subclass overrides remain authoritative even if a block handler is registered.