### PR TITLE
Update sticker API to current Bot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ types, while unimplemented items are intentionally left out of the public API.
   `edit_user_star_subscription`, `get_available_gifts`, `send_gift`,
   `gift_premium_subscription`, `get_sticker_set`, `upload_sticker_file`,
   `create_new_sticker_set`, `add_sticker_to_set`,
-  `set_sticker_position_in_set`, `delete_sticker_position_in_set`
+  `set_sticker_position_in_set`, `delete_sticker_from_set`
 - Bot commands and profile: `set_my_commands`, `get_my_commands`,
   `delete_my_commands`, `set_my_name`, `get_my_name`, `set_my_description`,
   `get_my_description`, `set_my_short_description`,
@@ -483,6 +483,7 @@ Override these methods in your bot subclass:
   `UniqueGiftInfo`, `UniqueGiftModel`, `UniqueGiftSymbol`,
   `UniqueGiftBackdrop`, `UniqueGiftBackdropColors`, `UniqueGiftColors`,
   `OwnedGift`, `OwnedGifts`
+- Stickers: `Sticker`, `StickerSet`, `InputSticker`, `MaskPosition`
 - Keyboards and Web Apps: `InlineKeyboardButton`, `InlineKeyboardMarkup`,
   `KeyboardButton`, `ReplyKeyboardMarkup`, `LoginUrl`, `WebAppInfo`,
   `WebAppData`, `SwitchInlineQueryChosenChat`, `CopyTextButton`,

--- a/spec/common_interaction_types_spec.cr
+++ b/spec/common_interaction_types_spec.cr
@@ -280,7 +280,7 @@ describe TelegramBot::Gift do
         "gifts": [
           {
             "id": "gift-id",
-            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "sticker": {"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
             "star_count": 100,
             "upgrade_star_count": 25,
             "background": {
@@ -300,7 +300,7 @@ describe TelegramBot::Gift do
         "gift": {
           "gift": {
             "id": "gift-id",
-            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "sticker": {"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
             "star_count": 100
           },
           "owned_gift_id": "owned-gift-id",
@@ -316,12 +316,12 @@ describe TelegramBot::Gift do
             "number": 1,
             "model": {
               "name": "Model",
-              "sticker": {"file_id": "model-sticker-id", "width": 512, "height": 512},
+              "sticker": {"file_id": "model-sticker-id", "file_unique_id": "model-sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
               "rarity_per_mille": 100
             },
             "symbol": {
               "name": "Symbol",
-              "sticker": {"file_id": "symbol-sticker-id", "width": 512, "height": 512},
+              "sticker": {"file_id": "symbol-sticker-id", "file_unique_id": "symbol-sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
               "rarity_per_mille": 100
             },
             "backdrop": {
@@ -339,7 +339,7 @@ describe TelegramBot::Gift do
         "gift_upgrade_sent": {
           "gift": {
             "id": "gift-id",
-            "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+            "sticker": {"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
             "star_count": 100
           }
         }
@@ -352,7 +352,7 @@ describe TelegramBot::Gift do
         "user": {"id": 1, "is_bot": false, "first_name": "User"},
         "gift": {
           "id": "gift-id",
-          "sticker": {"file_id": "sticker-id", "width": 512, "height": 512},
+          "sticker": {"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},
           "star_count": 100
         }
       }

--- a/spec/request_building_spec.cr
+++ b/spec/request_building_spec.cr
@@ -48,6 +48,10 @@ class RequestBuildingBot < TelegramBot::Bot
     "hideGeneralForumTopic",
     "unhideGeneralForumTopic",
     "unpinAllGeneralForumTopicMessages",
+    "createNewStickerSet",
+    "addStickerToSet",
+    "setStickerPositionInSet",
+    "deleteStickerFromSet",
   ]
 
   METHOD_RESPONSES = {
@@ -69,12 +73,14 @@ class RequestBuildingBot < TelegramBot::Bot
     "createChatSubscriptionInviteLink" => %({"invite_link":"https://t.me/+sub","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":false,"subscription_period":2592000,"subscription_price":100}),
     "editChatSubscriptionInviteLink"   => %({"invite_link":"https://t.me/+sub","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":false,"name":"Sub"}),
     "revokeChatInviteLink"             => %({"invite_link":"https://t.me/+invite","creator":{"id":1,"is_bot":true,"first_name":"Bot"},"creates_join_request":false,"is_primary":false,"is_revoked":true}),
-    "getForumTopicIconStickers"        => %([{"file_id":"sticker-id","width":512,"height":512}]),
+    "getForumTopicIconStickers"        => %([{"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false}]),
+    "getStickerSet"                    => %({"name":"set_name","title":"Sticker Set","sticker_type":"regular","stickers":[{"file_id":"sticker-id","file_unique_id":"sticker-id-unique","type":"regular","width":512,"height":512,"is_animated":false,"is_video":false}]}),
+    "uploadStickerFile"                => %({"file_id":"uploaded-sticker-id"}),
     "createForumTopic"                 => %({"message_thread_id":42,"name":"Topic","icon_color":7322096,"icon_custom_emoji_id":"emoji-id"}),
     "sendPaidMedia"                    => %({"message_id":1,"date":0,"chat":{"id":1,"type":"private"},"paid_media":{"star_count":10,"paid_media":[{"type":"preview","width":320,"height":240}]}}),
     "getMyStarBalance"                 => %({"amount":100,"nanostar_amount":500}),
     "getStarTransactions"              => %({"transactions":[{"id":"tx-id","amount":10,"date":1800000000,"source":{"type":"user","transaction_type":"paid_media_payment","user":{"id":1,"is_bot":false,"first_name":"User"},"paid_media_payload":"payload","paid_media":[{"type":"preview","width":320}]}}]}),
-    "getAvailableGifts"                => %({"gifts":[{"id":"gift-id","sticker":{"file_id":"sticker-id","width":512,"height":512},"star_count":100,"upgrade_star_count":25}]}),
+    "getAvailableGifts"                => %({"gifts":[{"id":"gift-id","sticker":{"file_id": "sticker-id", "file_unique_id": "sticker-id-unique", "type": "regular", "width": 512, "height": 512, "is_animated": false, "is_video": false},"star_count":100,"upgrade_star_count":25}]}),
     "answerGuestQuery"                 => %({"inline_message_id":"guest-inline-id"}),
     "getBusinessConnection"            => %({"id":"business-id","user":{"id":1,"is_bot":false,"first_name":"User"},"user_chat_id":100,"date":1800000000,"rights":{"can_reply":true},"is_enabled":true}),
     "getManagedBotToken"               => %("managed-token"),
@@ -927,6 +933,54 @@ describe TelegramBot::Bot do
     bot.last_method.should eq("unhideGeneralForumTopic")
     bot.unpin_all_general_forum_topic_messages("@group").should be_true
     bot.last_method.should eq("unpinAllGeneralForumTopicMessages")
+  end
+
+  it "builds sticker set methods" do
+    bot = RequestBuildingBot.new
+    input_sticker = TelegramBot::InputSticker.new(
+      "attach://sticker",
+      "static",
+      ["🙂"],
+      keywords: ["crystal"]
+    )
+
+    sticker_set = bot.get_sticker_set("set_name")
+    sticker_set.try(&.sticker_type).should eq("regular")
+    sticker_set.try(&.stickers.first.file_unique_id).should eq("sticker-id-unique")
+    bot.last_method.should eq("getStickerSet")
+
+    ::File.tempfile("sticker") do |file|
+      uploaded = bot.upload_sticker_file(1, file, "static")
+      uploaded.try(&.file_id).should eq("uploaded-sticker-id")
+    end
+    bot.last_method.should eq("uploadStickerFile")
+    bot.last_params.has_key?("png_sticker").should be_false
+    bot.last_params["sticker_format"].should eq("static")
+
+    bot.create_new_sticker_set(
+      1,
+      "set_name",
+      "Sticker Set",
+      [input_sticker],
+      sticker_type: "regular",
+      needs_repainting: true
+    ).should be_true
+    bot.last_method.should eq("createNewStickerSet")
+    bot.param("stickers").should contain("InputSticker")
+    bot.last_params.has_key?("png_sticker").should be_false
+    bot.last_params.has_key?("emojis").should be_false
+    bot.last_params.has_key?("contains_masks").should be_false
+
+    bot.add_sticker_to_set(1, "set_name", input_sticker).should be_true
+    bot.last_method.should eq("addStickerToSet")
+    bot.param("sticker").should contain("InputSticker")
+    bot.last_params.has_key?("png_sticker").should be_false
+
+    bot.set_sticker_position_in_set("sticker-id", 2).should be_true
+    bot.last_method.should eq("setStickerPositionInSet")
+
+    bot.delete_sticker_from_set("sticker-id").should be_true
+    bot.last_method.should eq("deleteStickerFromSet")
   end
 
   it "builds multipart bodies with serialized non-file params" do

--- a/src/telegram_bot/bot/methods/stickers.cr
+++ b/src/telegram_bot/bot/methods/stickers.cr
@@ -19,12 +19,14 @@ module TelegramBot
     # See: <https://core.telegram.org/bots/api#uploadstickerfile>
     def upload_sticker_file(
       user_id : Int,
-      png_sticker : ::File,
+      sticker : ::File,
+      sticker_format : String,
     )
       res = def_request(
         "uploadStickerFile",
         user_id,
-        png_sticker
+        sticker,
+        sticker_format
       )
       File.from_json(res.to_json) if res
     end
@@ -36,20 +38,18 @@ module TelegramBot
       user_id : Int,
       name : String,
       title : String,
-      png_sticker : ::File | String,
-      emojis : String,
-      contains_masks : Bool? = nil,
-      mask_position : MaskPosition? = nil,
+      stickers : Array(InputSticker),
+      sticker_type : String? = nil,
+      needs_repainting : Bool? = nil,
     )
       res = def_request(
         "createNewStickerSet",
         user_id,
         name,
         title,
-        png_sticker,
-        emojis,
-        contains_masks,
-        mask_position
+        stickers,
+        sticker_type,
+        needs_repainting
       )
 
       res.as_bool if res
@@ -61,17 +61,13 @@ module TelegramBot
     def add_sticker_to_set(
       user_id : Int,
       name : String,
-      png_sticker : ::File | String,
-      emojis : String,
-      mask_position : MaskPosition? = nil,
+      sticker : InputSticker,
     )
       res = def_request(
         "addStickerToSet",
         user_id,
         name,
-        png_sticker,
-        emojis,
-        mask_position
+        sticker
       )
 
       res.as_bool if res
@@ -96,7 +92,7 @@ module TelegramBot
     # Deletes a sticker from a sticker set.
     #
     # See: <https://core.telegram.org/bots/api#deletestickerfromset>
-    def delete_sticker_position_in_set(sticker : String)
+    def delete_sticker_from_set(sticker : String)
       res = def_request(
         "deleteStickerFromSet",
         sticker

--- a/src/telegram_bot/types/input_sticker.cr
+++ b/src/telegram_bot/types/input_sticker.cr
@@ -1,0 +1,20 @@
+module TelegramBot
+  class InputSticker
+    include JSON::Serializable
+
+    property sticker : String
+    property format : String
+    property emoji_list : Array(String)
+    property mask_position : MaskPosition?
+    property keywords : Array(String)?
+
+    def initialize(
+      @sticker : String,
+      @format : String,
+      @emoji_list : Array(String),
+      @mask_position : MaskPosition? = nil,
+      @keywords : Array(String)? = nil,
+    )
+    end
+  end
+end

--- a/src/telegram_bot/types/sticker.cr
+++ b/src/telegram_bot/types/sticker.cr
@@ -3,12 +3,19 @@ module TelegramBot
     include JSON::Serializable
 
     property file_id : String
+    property file_unique_id : String
+    property type : String
     property width : Int32
     property height : Int32
+    property? is_animated : Bool
+    property? is_video : Bool
     property thumbnail : PhotoSize?
     property emoji : String?
     property set_name : String?
+    property premium_animation : File?
     property mask_position : MaskPosition?
+    property custom_emoji_id : String?
+    property? needs_repainting : Bool?
     property file_size : Int32?
   end
 end

--- a/src/telegram_bot/types/sticker_set.cr
+++ b/src/telegram_bot/types/sticker_set.cr
@@ -4,7 +4,8 @@ module TelegramBot
 
     property name : String
     property title : String
-    property? contains_masks : Bool
+    property sticker_type : String
     property stickers : Array(Sticker)
+    property thumbnail : PhotoSize?
   end
 end


### PR DESCRIPTION
## Summary

Updates the sticker API wrappers and types to match the current Telegram Bot API shape.

## Changes

- Add `TelegramBot::InputSticker`
- Update `upload_sticker_file` to use `sticker` and required `sticker_format`
- Update `create_new_sticker_set` to use `stickers : Array(InputSticker)`, `sticker_type`, and `needs_repainting`
- Update `add_sticker_to_set` to use `sticker : InputSticker`
- Replace the misleading `delete_sticker_position_in_set` wrapper with `delete_sticker_from_set`
- Update `Sticker` with current fields:
  - `file_unique_id`
  - `type`
  - `is_animated`
  - `is_video`
  - `premium_animation`
  - `custom_emoji_id`
  - `needs_repainting`
- Update `StickerSet` with current fields:
  - `sticker_type`
  - `thumbnail`
- Remove outdated sticker API fields/parameters from the public API
- Update README method/type lists
- Update request-building and parsing fixtures for current sticker fields